### PR TITLE
GHA: pre-release + release actions

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,41 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+
+      - name: Install Drools Snapshot
+        uses: actions/checkout@v3
+        with:
+          repository: kiegroup/drools
+          path: drools
+
+      - name: Build Drools Snapshot with Maven
+        run: cd drools && mvn --batch-mode --update-snapshots install -Dquickly && cd ..
+
+      - uses: actions/checkout@v3
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+      - run: mkdir staging && cp drools-ansible-rulebook-integration-durable-rest/target/*-runner.jar staging
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            staging/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  build:
+  tagged-release:
+    name: "Tagged Release"
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +31,10 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify
       - run: mkdir staging && cp drools-ansible-rulebook-integration-durable-rest/target/*-runner.jar staging
-      - uses: actions/upload-artifact@v3
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          name: Package
-          path: staging
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            staging/*.jar


### PR DESCRIPTION
Add pre-release.yml and release.yml (superseding the old build.yml)
- creates a tag+release `latest` for each merge on `main`. Attached is a jar with the latest successful build; e.g. see https://github.com/evacchi/drools-ansible-rulebook-integration/releases/tag/latest
- creates a release for each tag pushed to main. Attached is the jar with the build for that tag; e.g. see https://github.com/evacchi/drools-ansible-rulebook-integration/releases/tag/v1.0.0