### PR TITLE
Bump to Drools 8.30.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.drools>8.30.0-SNAPSHOT</version.drools>
+    <version.drools>8.30.0.Final</version.drools>
     <version.quarkus>2.11.2.Final</version.quarkus>
     <version.junit>4.13.2</version.junit>
     <version.assertj>3.20.2</version.assertj>


### PR DESCRIPTION
Memo: remember to tag the release

- GHA: pre-release + release actions
- Use shade-maven-plugin instead of Quarkus uber-jar
- fix: only upload shaded jar
- Bump 8.30.0.Final
