### PR TITLE
[DROOLS-7414] BigDecimal equality with different scale

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/ListContainsConstraint.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/ListContainsConstraint.java
@@ -5,7 +5,7 @@ import java.util.function.BiPredicate;
 
 import org.drools.model.ConstraintOperator;
 
-import static org.drools.ansible.rulebook.integration.api.domain.constraints.Operators.areEqual;
+import static org.drools.model.util.OperatorUtils.areEqual;
 
 public enum ListContainsConstraint implements ConstraintOperator {
 

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/Operators.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/Operators.java
@@ -1,9 +1,7 @@
 package org.drools.ansible.rulebook.integration.api.domain.constraints;
 
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 
@@ -54,25 +52,5 @@ public class Operators {
             }
             return false;
         }
-    }
-
-    static boolean areEqual(Object o1, Object o2) {
-        return o1 instanceof Number && o2 instanceof Number ? areNumericEqual((Number) o1, (Number) o2) : Objects.equals(o1, o2);
-    }
-
-    static <T, V> boolean areNumericEqual(Number n1, Number n2) {
-        return n1.getClass() != n2.getClass() ?
-                asBigDecimal(n1).equals(asBigDecimal(n2)) :
-                Objects.equals(n1, n2);
-    }
-
-    static int compare(Object o1, Object o2) {
-        return o1.getClass() != o2.getClass() && o1 instanceof Number && o2 instanceof Number ?
-                asBigDecimal(o1).compareTo(asBigDecimal(o2)) :
-                ((Comparable) o1).compareTo(o2);
-    }
-
-    static BigDecimal asBigDecimal(Object obj) {
-        return obj instanceof BigDecimal ? (BigDecimal) obj : BigDecimal.valueOf(((Number) obj).doubleValue());
     }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ListContainsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ListContainsTest.java
@@ -264,6 +264,10 @@ public class ListContainsTest {
         assertEquals( 1, matchedRules.size() );
         assertEquals( "contains_rule_int", matchedRules.get(0).getRule().getName() );
 
+        matchedRules = rulesExecutor.processFacts( "{ \"id_list\" : [3,1021.00] }" ).join(); // 1021.00 becomes BigDecimal("1021.00") by RulesModelUtil.asFactMap()
+        assertEquals( 1, matchedRules.size() );
+        assertEquals( "contains_rule_int", matchedRules.get(0).getRule().getName() );
+
         rulesExecutor.dispose();
     }
 

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/LogicalOperatorsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/LogicalOperatorsTest.java
@@ -664,7 +664,7 @@ public class LogicalOperatorsTest {
                 "                                            \"Event\": \"i\"\n" +
                 "                                        },\n" +
                 "                                        \"rhs\": {\n" +
-                "                                            \"Float\": 3.0\n" +
+                "                                            \"Float\": 3.0\n" + // 3.0 becomes BigDecimal("3.0") by ConditionParseUtil.toJsonValue()
                 "                                        }\n" +
                 "                                    }\n" +
                 "                                }\n" +
@@ -689,6 +689,9 @@ public class LogicalOperatorsTest {
         RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(json);
 
         List<Match> matchedRules = rulesExecutor.processEvents( "{ \"i\":3, \"action\":\"go\" }" ).join();
+        assertEquals( 1, matchedRules.size() );
+
+        matchedRules = rulesExecutor.processEvents( "{ \"i\":3.00, \"action\":\"go\" }" ).join(); // 3.00 becomes BigDecimal("3.00") by RulesModelUtil.asFactMap()
         assertEquals( 1, matchedRules.size() );
 
         rulesExecutor.dispose();

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/domain/constraints/ListContainsConstraintTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/domain/constraints/ListContainsConstraintTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.ansible.rulebook.integration.api.domain.constraints;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListContainsConstraintTest {
+
+    @Test
+    public void integerListAgainstBigDecimal() {
+        List<Integer> list = Arrays.asList(1, 2, 3);
+        boolean result = ListContainsConstraint.INSTANCE.asPredicate().test(list, new BigDecimal("1.0"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void doubleListAgainstBigDecimal() {
+        List<Double> list = Arrays.asList(1.0, 2.0, 3.0);
+        boolean result = ListContainsConstraint.INSTANCE.asPredicate().test(list, new BigDecimal("1.0"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void bigDecimalListAgainstInteger() {
+        List<BigDecimal> list = Arrays.asList(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("3.0"));
+        boolean result = ListContainsConstraint.INSTANCE.asPredicate().test(list, 1);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void bigDecimalListWithDifferentScaleAgainstBigDecimal() {
+        List<BigDecimal> list = Arrays.asList(new BigDecimal("1"), new BigDecimal("1.00"));
+        boolean result = ListContainsConstraint.INSTANCE.asPredicate().test(list, new BigDecimal("1.0"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void bigDecimalListWithDifferentScaleAgainstInteger() {
+        List<BigDecimal> list = Arrays.asList(new BigDecimal("1"), new BigDecimal("1.00"));
+        boolean result = ListContainsConstraint.INSTANCE.asPredicate().test(list, 1);
+        assertThat(result).isTrue();
+    }
+}

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/toexecmodel/MapConditionToPatternRelationalOperatorsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/toexecmodel/MapConditionToPatternRelationalOperatorsTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.ansible.rulebook.integration.api.toexecmodel;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 
 import org.drools.ansible.rulebook.integration.api.domain.conditions.MapCondition;
@@ -44,6 +45,31 @@ public class MapConditionToPatternRelationalOperatorsTest extends ToPatternTestB
 
         Event event2 = createIJEvent(2, 2);
         assertThat(predicate.test(event2)).isTrue();
+    }
+
+    @Test
+    public void equalsExpression_BigDecimalDifferentScale() throws Exception {
+        // Create MapCondition
+        LinkedHashMap<Object, Object> lhsValueMap = createEventField("i");
+        LinkedHashMap<Object, Object> rhsValueMap = createSingleMap("Integer", 1.0); // actually, this will be BigDecimal("1.0")
+        LinkedHashMap<Object, Object> equalsExpression = createEqualsExpression(lhsValueMap, rhsValueMap);
+        LinkedHashMap<Object, Object> rootMap = createAllCondition(equalsExpression);
+        MapCondition mapCondition = new MapCondition(rootMap);
+
+        // toPattern and extract its predicate
+        Predicate1.Impl predicate = toPatternAndGetFirstPredicate(mapCondition);
+
+        Event event1 = createIEvent(0);
+        assertThat(predicate.test(event1)).isFalse();
+
+        Event event2 = createIEvent(1);
+        assertThat(predicate.test(event2)).isTrue();
+
+        Event event3 = createIEvent(new BigDecimal("1.0"));
+        assertThat(predicate.test(event3)).isTrue();
+
+        Event event4 = createIEvent(new BigDecimal("1.00")); // different scale
+        assertThat(predicate.test(event4)).isTrue();
     }
 
     @Test

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/toexecmodel/ToPatternTestBase.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/toexecmodel/ToPatternTestBase.java
@@ -54,6 +54,12 @@ public class ToPatternTestBase {
         return createEvent(factMap);
     }
 
+    protected Event createIEvent(Object i) {
+        Map<String, Object> factMap = new HashMap<>();
+        factMap.put("i", i);
+        return createEvent(factMap);
+    }
+
     protected Event createIJEvent(Object i, Object j) {
         Map<String, Object> factMap = new HashMap<>();
         factMap.put("i", i);


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7414

In Ansible Integration, 1.0 and 1.00 are not equal.
`ListContainsExpression` uses `org.drools.ansible.rulebook.integration.api.domain.constraints.Operators.areNumericEqual`
`EqualsExpression` uses `org.drools.model.Index.areNumericEqual`

This PR is to move methods including `areNumericEqual` from `Index` to new `OperatorUtils` and let both `ListContainsExpression` and `EqualsExpression` use `OperatorUtils`.

**referenced Pull Requests**: 

* https://github.com/kiegroup/drools/pull/5194
