### PR TITLE
[DROOLS-7434] Suppress DefaultAgenda debug log

### DIFF
--- a/drools-ansible-rulebook-integration-runtime/src/main/resources/simplelogger.properties
+++ b/drools-ansible-rulebook-integration-runtime/src/main/resources/simplelogger.properties
@@ -1,0 +1,3 @@
+# Basically, leave simpleLogger configurations to a caller (drools_jpy). Just add specific configurations here.
+
+org.slf4j.simpleLogger.log.org.drools.kiesession.agenda.DefaultAgenda=info


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7434

Suppress `DefaultAgenda` debug log.
There are possible approaches:

1. Configure log level in `drools_jpy` : (pros) `drools_jpy` is a caller who can control log levels. (cons) `drools_jpy` manipulates String for  JVM options in `ruleset.py` so it could be a little messy
2. Include simplelogger.properties in drools-ansible-rulebook-integration-runtime jar : (pros) Hide the details that probably `drools_jpy` doesn't need to know. 
3. Change the log level of those messages to TRACE in `drools-core` : (pros) The log may be too verbose to other use cases.

This PR chooses 2.

Confirmed with `drools_jpy` locally that the change suppresses the DefaultAgenda debug logs.

Note: `drools_jpy` can overwrite the simpleLogger configurations with providing system properties.