### PR TITLE
[1.0.x] Upgrade nightly drools mapping to 8.38.x on nightly

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -4,7 +4,7 @@ dependencies:
     mapping:
       dependant:
         default:
-          - source: 8.36.x
+          - source: 8.38.x
             target: 1.0.x
 
   - project: kiegroup/drools-ansible-rulebook-integration
@@ -14,4 +14,4 @@ dependencies:
       dependencies:
         default:
           - source: 1.0.x
-            target: 8.36.x
+            target: 8.38.x


### PR DESCRIPTION
**Backport:** https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/31
