### PR TITLE
DROOLS-7456 avoid kie maven plugin to crash on jdk17 project

### DIFF
--- a/drools-ansible-rulebook-integration-benchmark/pom.xml
+++ b/drools-ansible-rulebook-integration-benchmark/pom.xml
@@ -51,6 +51,16 @@
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/drools-ansible-rulebook-integration-runtime/pom.xml
+++ b/drools-ansible-rulebook-integration-runtime/pom.xml
@@ -41,6 +41,16 @@
         <version>3.4.1</version>
         <configuration>
           <minimizeJar>true</minimizeJar>
+          <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+            <filter>
+            <artifact>*:*</artifact>
+            <excludes>
+                  <exclude>META-INF/*.SF</exclude>
+                  <exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude>
+            </excludes>
+            </filter>
+          </filters>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7456

**referenced Pull Requests**: 

* requires first a new version of MVEL: https://github.com/mvel/mvel/pull/330
* https://github.com/kiegroup/drools/pull/5267
* https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/48

**Details**:

* drools-ecj is de-shaded, so shading `ECJ` as a dependency the new version containing checksum requires dropping these files from the `ECJ artifact` when building the bundled uber-jar / fat jar creation.