### PR TITLE
bump drools to 8.42.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.drools>8.41.0-SNAPSHOT</version.drools>
+    <version.drools>8.42.0-SNAPSHOT</version.drools>
     <version.quarkus>2.11.2.Final</version.quarkus>
     <version.junit>4.13.2</version.junit>
     <version.assertj>3.20.2</version.assertj>


### PR DESCRIPTION
This bump is also required to run healthy CI.