### PR TITLE
simplify repo lookup for contributors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,55 @@
     <version.jmh>1.35</version.jmh>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Problem
an (external?) contributor or a kiegroup member without a custom `~/.m2/settings.xml` set with explicit jboss nexus, would not be able to make the build out of the box:
<img width="1680" alt="Screenshot 2023-07-25 at 08 46 58" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/9ec0f728-f294-4c63-8b21-a9a816cf6dbd">

This is because Drools snapshot are published only to jboss nexus, not to maven central.
Further, GHA does not have this problem simply because, correctly, they checkout Drools and build it fast as part of the CI on this repo.
But this is a problem for the personas identified above.

Solution
Implement repo explicitly in `pom.xml`, similarly to other repo/projects in kiegroup.