### PR TITLE
DROOLS-7514 strict JSON parsing with Jackson

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/io/JsonMapper.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/io/JsonMapper.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -17,10 +16,6 @@ public class JsonMapper {
     private static final TypeReference<List<Map<String, Object>>> LIST_OF_MAP_OF_STRING_AND_OBJECT = new TypeReference<List<Map<String, Object>>>(){};
     private static final TypeReference<Map<String, Object>> MAP_OF_STRING_AND_OBJECT = new TypeReference<Map<String, Object>>(){};
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    static { // most tests contains non-standard JSON; eventually check assumption non-strict json with Ansible team
-        OBJECT_MAPPER.enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES.mappedFeature());
-        OBJECT_MAPPER.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature());
-    }
     private static final JavaType JACKSON_RAW_LIST = OBJECT_MAPPER.getTypeFactory().constructRawCollectionLikeType(List.class);
 
     public static String toJson(Object object) {

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ArrayAccessTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ArrayAccessTest.java
@@ -38,10 +38,10 @@ public class ArrayAccessTest {
     public void testArrayAccess() {
         RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON1);
 
-        List<Match> matchedRules = rulesExecutor.processFacts( "{'host': 'A', 'os': {'array': ['abc']}}" ).join();
+        List<Match> matchedRules = rulesExecutor.processFacts( "{\"host\": \"A\", \"os\": {\"array\": [\"abc\"]}}" ).join();
         assertEquals( 0, matchedRules.size() );
 
-        matchedRules = rulesExecutor.processFacts( "{'host': 'B', 'os': {'array': ['abc', 'windows']}}" ).join();
+        matchedRules = rulesExecutor.processFacts( "{\"host\": \"B\", \"os\": {\"array\": [\"abc\", \"windows\"]}}" ).join();
         assertEquals( 1, matchedRules.size() );
         assertEquals( "r_0", matchedRules.get(0).getRule().getName() );
 

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/LogicalOperatorsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/LogicalOperatorsTest.java
@@ -140,7 +140,7 @@ public class LogicalOperatorsTest {
         assertEquals( 1, matchedRules.size() );
         assertEquals( "R1", matchedRules.get(0).getRule().getName() );
 
-        matchedRules = rulesExecutor.processFacts( "{ facts: [ { \"sensu\": { \"data\": { \"i\":3 } } }, { \"j\":3 } ] }" ).join();
+        matchedRules = rulesExecutor.processFacts( "{ \"facts\": [ { \"sensu\": { \"data\": { \"i\":3 } } }, { \"j\":3 } ] }" ).join();
         assertEquals( 0, matchedRules.size() );
 
         matchedRules = rulesExecutor.processFacts( "{ \"sensu\": { \"data\": { \"i\":4 } } }" ).join();

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MultipleConditionTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MultipleConditionTest.java
@@ -87,7 +87,7 @@ public class MultipleConditionTest {
     public void testReadJson() {
         RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON1);
 
-        List<Match> matchedRules = rulesExecutor.processEvents( "{ events: [ { \"i\":0 }, { \"i\":1 }, { \"i\":2 } ] }" ).join();
+        List<Match> matchedRules = rulesExecutor.processEvents( "{ \"events\": [ { \"i\":0 }, { \"i\":1 }, { \"i\":2 } ] }" ).join();
 
         assertEquals( 1, matchedRules.size() );
         assertEquals( "r_0", matchedRules.get(0).getRule().getName() );

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/NullTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/NullTest.java
@@ -63,7 +63,7 @@ public class NullTest {
 
         RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(json);
 
-        List<Match> matchedRules = rulesExecutor.processFacts( "{ \"x\":1, y:null }" ).join();
+        List<Match> matchedRules = rulesExecutor.processFacts( "{ \"x\":1, \"y\":null }" ).join();
         assertEquals( 1, matchedRules.size() );
 
         matchedRules = rulesExecutor.processFacts( "{ \"x\":1 }" ).join();
@@ -164,7 +164,7 @@ public class NullTest {
 
         RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(json);
 
-        List<Match> matchedRules = rulesExecutor.processFacts( "{ \"x\":1, y:null }" ).join();
+        List<Match> matchedRules = rulesExecutor.processFacts( "{ \"x\":1, \"y\":null }" ).join();
         assertEquals( 1, matchedRules.size() );
         assertEquals( "r1", matchedRules.get(0).getRule().getName() );
 

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/SimpleLogicalOperatorsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/SimpleLogicalOperatorsTest.java
@@ -92,7 +92,7 @@ public class SimpleLogicalOperatorsTest {
         assertEquals( 1, matchedRules.size() );
         assertEquals( "R1", matchedRules.get(0).getRule().getName() );
 
-        matchedRules = rulesExecutor.processFacts( "{ facts: [ { \"sensu\": { \"data\": { \"i\":3 } } }, { \"j\":3 } ] }" ).join();
+        matchedRules = rulesExecutor.processFacts( "{ \"facts\": [ { \"sensu\": { \"data\": { \"i\":3 } } }, { \"j\":3 } ] }" ).join();
         assertEquals( 0, matchedRules.size() );
 
         matchedRules = rulesExecutor.processFacts( "{ \"sensu\": { \"data\": { \"i\":4 } } }" ).join();


### PR DESCRIPTION
ref https://issues.redhat.com/browse/DROOLS-7514

Tested locally by:

Step1: on this project
```
mvn clean install
cp drools-ansible-rulebook-integration-runtime/target/drools-ansible-rulebook-integration-runtime-1.0.3-SNAPSHOT.jar ../drools_jpy/src/drools/jars/
```
<img width="1788" alt="Screenshot 2023-07-25 at 12 41 56" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/f5b77a98-5a48-4368-8953-1dd74b13ea05">

Step2: on drools_jpy "pretend" an ad-hoc version
```
pytest -vv -s
python3 -m pip install .
```
<img width="1788" alt="Screenshot 2023-07-25 at 12 41 59" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/28877382-404f-4179-98a4-22507a6dfdcf">

(note: using "same" venv between drools_jpy and ansible-rulebook)

Step3: on ansible-rulebook "pretend" to use the "pretend-drools-jpy-version" and check the same commands per ansible-rulebook CI on GitHub action:
```
pip install -e .
pip install -r requirements_dev.txt
pytest -m "e2e" -n auto 
pytest -m "not e2e and not long_run" -vv -n auto
```
<img width="1788" alt="Screenshot 2023-07-25 at 12 42 05" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/24f4593d-3863-4f10-bd14-075247a3cb83">
<img width="1788" alt="Screenshot 2023-07-25 at 12 43 28" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/cd968acb-4384-412c-9523-1a12fe4c23b6">

(the only 1 failure in the last screenshot is indeed due to the "pretend" version since `0.3.5.1` for the drools_jpy version does not match test assertions, but it;'s fine as it's only a pretend-version for the scope of this manual testing locally across the 3 projects)
