### PR TITLE
Introduce fully manual pseudoclock opt (no auto advance)

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/RuleConfigurationOption.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/RuleConfigurationOption.java
@@ -3,5 +3,12 @@ package org.drools.ansible.rulebook.integration.api;
 public enum RuleConfigurationOption {
     EVENTS_PROCESSING,
     USE_PSEUDO_CLOCK,
+    /**
+     * When this option is set, there is no automatic advance of the internal pseudoclock.
+     * This option is intended for use in testing
+     * (avoid during debug session for the pseudoclock to diverge
+     * because of the default automatic advancements)
+     */
+    FULLY_MANUAL_PSEUDOCLOCK,
     ASYNC_EVALUATION
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/OnceAfterTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/OnceAfterTest.java
@@ -297,7 +297,7 @@ public class OnceAfterTest {
                 "]\n" + //
                 "}";
 
-        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(RuleNotation.CoreNotation.INSTANCE.withOptions(RuleConfigurationOption.USE_PSEUDO_CLOCK), RULES);
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(RuleNotation.CoreNotation.INSTANCE.withOptions(RuleConfigurationOption.FULLY_MANUAL_PSEUDOCLOCK), RULES);
         List<Match> matchedRules;
 
         source_generic_loop57(rulesExecutor);


### PR DESCRIPTION
When the option is set, there is no automatic advance of the internal pseudoclock. This option is intended for use in testing
(avoid during debug session for the pseudoclock to diverge because of the default automatic advancements).

Before:
<img width="1792" alt="Screenshot 2023-07-31 at 10 40 34" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/16ea2944-8dd6-4da1-9091-93ff4b5e141c">

Notice the log lines of pseudo-clock diverging, because the human user is taking the time while debugging

After:
<img width="1792" alt="Screenshot 2023-07-31 at 10 41 22" src="https://github.com/kiegroup/drools-ansible-rulebook-integration/assets/1699252/b30ba97e-5be4-424e-926f-e9d5aa82938c">

Notice no lines of pseudo-clock diverged warnings.