### PR TITLE
update Jenkinsfile.prod.nightly to use jdk17

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -6,7 +6,7 @@ pipeline{
     }
     tools {
       maven 'kie-maven-3.8.7'
-      jdk 'kie-jdk11'
+      jdk 'kie-jdk17'
       nodejs 'nodejs-16.2.0'
     }
     parameters {


### PR DESCRIPTION
This change is related to https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/68