### PR TITLE
explicit antlr4 version

### DIFF
--- a/drools-ansible-rulebook-integration-protoextractor/pom.xml
+++ b/drools-ansible-rulebook-integration-protoextractor/pom.xml
@@ -24,7 +24,8 @@
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId> 
+      <artifactId>antlr4-runtime</artifactId>
+      <version>${version.org.antlr4}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
In order to avoid a wrong version inherited from productized drools `build-parent/pom.xml`, use the explicit antlr4 version.