### PR TITLE
[DROOLS-7575] ansible-drools-integration incompatible ANTLR : 2nd round

### DIFF
--- a/drools-ansible-rulebook-integration-protoextractor/pom.xml
+++ b/drools-ansible-rulebook-integration-protoextractor/pom.xml
@@ -25,7 +25,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>${version.org.antlr4}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,11 +87,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-          <groupId>org.kie</groupId>
-          <artifactId>drools-build-parent</artifactId>
-          <version>${version.drools}</version>
-          <type>pom</type>
-          <scope>import</scope>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-runtime</artifactId>
+        <version>${version.org.antlr4}</version> <!-- this local dependency management takes precedence over the below import -->
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>drools-build-parent</artifactId>
+        <version>${version.drools}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This dependencyManagement makes sure to use the expected antlr4 version in all sub modules.

https://issues.redhat.com/browse/DROOLS-7575