### PR TITLE
[DROOLS-7589] add memory occupation to session stats + optionally exit above memory threshold

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStats.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStats.java
@@ -103,6 +103,8 @@ public class SessionStats {
                 ", ruleSetName='" + ruleSetName + '\'' +
                 ", lastRuleFired='" + lastRuleFired + '\'' +
                 ", lastRuleFiredAt='" + lastRuleFiredAt + '\'' +
+                ", usedMemory='" + getUsedMemory() + '\'' +
+                ", maxAvailableMemory='" + getMaxAvailableMemory() + '\'' +
                 '}';
     }
 
@@ -176,6 +178,14 @@ public class SessionStats {
 
     public int getClockAdvanceCount() {
         return clockAdvanceCount;
+    }
+
+    public long getUsedMemory() {
+        return MemoryMonitorUtil.getUsedMemory();
+    }
+
+    public long getMaxAvailableMemory() {
+        return MemoryMonitorUtil.getMaxAvailableMemory();
     }
 
     public static SessionStats aggregate(SessionStats stats1, SessionStats stats2) {


### PR DESCRIPTION
@tkobayas These are the minor changes that I agreed with Madhu during yesterday's call. Even though the memory occupation doesn't belong to a single session but it's referred to the whole JVM, he said that it would be interesting to have that value reported among the session stats. In future, in case we will find more of these values referred to the entire system, we may want to add a proper `SystemStats` object and move also the memory stats there. Moreover he wanted the possibility to optionally kill the JVM when the memory threshold is reached. I'm not entirely sure if how I implemented this makes sense or there is a better alternative, so please double check it and feel free to propose better options. 