### PR TITLE
Adding isDefinedAndIsNotDefined test

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
@@ -189,4 +189,58 @@ public class ProcessEventTest {
 
         rulesExecutor.dispose();
     }
+
+    public static final String JSON_IS_DEFINED_AND_IS_NOT_DEFINED =
+            """
+            {
+                "rules": [
+                    {
+                        "Rule": {
+                            "name": "r1",
+                            "condition": {
+                                "AllCondition": [
+                                    {
+                                        "AndExpression": {
+                                            "lhs": {
+                                                "IsDefinedExpression": {
+                                                    "Event": "meta"
+                                                }
+                                            },
+                                            "rhs": {
+                                                "IsNotDefinedExpression": {
+                                                    "Event": "meta.headers.token"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "actions": [
+                                {
+                                    "Action": {
+                                        "action": "debug",
+                                        "action_args": {}
+                                    }
+                                }
+                            ],
+                            "enabled": true
+                        }
+                    }
+                ]
+            }
+            """;
+
+    @Test
+    public void isDefinedAndIsNotDefinedExpression() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_IS_DEFINED_AND_IS_NOT_DEFINED);
+
+        List<Match> matchedRules = rulesExecutor.processEvents("{\"meta\":{\"headers\":{\"token\":123}}}").join();
+        assertEquals(0, matchedRules.size());
+
+        matchedRules = rulesExecutor.processEvents("{\"meta\":{\"headers\":{\"age\":23}}}").join();
+        assertEquals(1, matchedRules.size());
+        assertEquals("r1", matchedRules.get(0).getRule().getName());
+
+        rulesExecutor.dispose();
+    }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
@@ -243,4 +243,54 @@ public class ProcessEventTest {
 
         rulesExecutor.dispose();
     }
+
+    public static final String JSON_IS_DEFINED_IS_NOT_DEFINED_IN_ALL =
+            """
+            {
+                "rules": [
+                    {
+                        "Rule": {
+                            "name": "r1",
+                            "condition": {
+                                "AllCondition": [
+                                    {
+                                        "IsDefinedExpression": {
+                                            "Event": "meta"
+                                        }
+                                    },
+                                    {
+                                        "IsNotDefinedExpression": {
+                                            "Event": "meta.headers.token"
+                                        }
+                                    }
+                                ]
+                            },
+                            "actions": [
+                                {
+                                    "Action": {
+                                        "action": "debug",
+                                        "action_args": {}
+                                    }
+                                }
+                            ],
+                            "enabled": true
+                        }
+                    }
+                ]
+            }
+            """;
+
+    @Test
+    public void isDefinedIsNotDefinedInAllExpression() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_IS_DEFINED_IS_NOT_DEFINED_IN_ALL);
+
+        List<Match> matchedRules = rulesExecutor.processEvents("{\"meta\":{\"headers\":{\"token\":123}}}").join();
+        assertEquals(0, matchedRules.size());
+
+        matchedRules = rulesExecutor.processEvents("{\"meta\":{\"headers\":{\"age\":23}}}").join();
+        assertEquals(1, matchedRules.size());
+        assertEquals("r1", matchedRules.get(0).getRule().getName());
+
+        rulesExecutor.dispose();
+    }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/ProcessEventTest.java
@@ -190,6 +190,7 @@ public class ProcessEventTest {
         rulesExecutor.dispose();
     }
 
+    // condition: event.meta is defined and event.meta.headers.token is not defined
     public static final String JSON_IS_DEFINED_AND_IS_NOT_DEFINED =
             """
             {
@@ -244,6 +245,10 @@ public class ProcessEventTest {
         rulesExecutor.dispose();
     }
 
+    //  condition:
+    //    all:
+    //      - event.meta is defined
+    //      - event.meta.headers.token is not defined
     public static final String JSON_IS_DEFINED_IS_NOT_DEFINED_IN_ALL =
             """
             {


### PR DESCRIPTION
This test fails because IsNotDefinedExpression doesn't handle negation.

- `ExistsField.createParsedCondition` handles only `notPattern` (But we need to decide whether `notPattern` or `negate` based on the parent condition)
- Even if negate == true, `PrototypePatternDefImpl.evaluateConstraint` always returns false when a value is  `UNDEFINED_VALUE` regardless of `operator`. We would need special handling?

ReteDumper:
```
[EntryPointNode(1) EntryPoint::DEFAULT ] on Partition(MAIN)
  [ObjectTypeNode(3)::EntryPoint::DEFAULT objectType=[PrototypeObjectType template=DROOLS_PROTOTYPE] expiration=-1ms ] on Partition(MAIN)
    [AlphaNode(4) constraint=[Constraint for 'expr:ThisPrototypeFieldValue:EXISTS_FIELD:ExtractorPrototypeExpression{ExtractorNode [values=[IdentifierNode [value=meta]]]}' (index: null), ]] on Partition(1) d -1 i -1
      [AlphaNode(5) constraint=[Constraint for 'expr:ThisPrototypeFieldValue:EXISTS_FIELD:ExtractorPrototypeExpression{ExtractorNode [values=[IdentifierNode [value=meta], IdentifierNode [value=headers], IdentifierNode [value=token]]]}' (index: null), ]] on Partition(1) d -1 i -1
        [AlphaTerminalNode(6)] on Partition(1) Ld 0 Li 0
          [RuleTerminalNode(7): rule=r1] on Partition(1) d -1 i -1
  [ObjectTypeNode(2)::EntryPoint::DEFAULT objectType=[ClassObjectType class=org.drools.base.reteoo.InitialFactImpl] expiration=-1ms ] on Partition(MAIN)
```