### PR TITLE
[1.0.x][drools-ansible-rulebook-integration-113] Adjust project dependencies for build-chain

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -29,7 +29,7 @@ pipeline{
           script {
             // Fetch versions from pom if not provided
             env.PRODUCT_VERSION = "${PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools-ansible-rulebook-integration')}"
-            env.DROOLS_PRODUCT_VERSION = "${DROOLS_PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools', '8.43.x')}"
+            env.DROOLS_PRODUCT_VERSION = "${DROOLS_PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools', '9.101.x-prod')}"
           }
 
           sh 'printenv'

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -5,7 +5,7 @@ dependencies:
       dependant:
         default:
           # whenever drools branch changes, please update .ci/jenkins/Jenkinsfile.prod.nightly as well if needed
-          - source: 8.43.x
+          - source: 9.101.x-prod
             target: 1.0.x
 
   - project: kiegroup/drools-ansible-rulebook-integration
@@ -15,4 +15,4 @@ dependencies:
       dependencies:
         default:
           - source: 1.0.x
-            target: 8.43.x
+            target: 9.101.x-prod


### PR DESCRIPTION
Consider dependency drools version for drools-ansible-rulebook-integration 1.0.x

https://github.com/kiegroup/drools-ansible-rulebook-integration/issues/113