### PR TITLE
[incubator-kie-drools-6100] Adjust drools-ansible integration GHA

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -5,7 +5,7 @@ dependencies:
       dependant:
         default:
           # whenever drools branch changes, please update .ci/jenkins/Jenkinsfile.prod.nightly as well if needed
-          - source: 8.43.x
+          - source: 9.101.x-prod
             target: 1.0.x
 
   - project: kiegroup/drools-ansible-rulebook-integration
@@ -15,4 +15,4 @@ dependencies:
       dependencies:
         default:
           - source: 1.0.x
-            target: 8.43.x
+            target: 9.101.x-prod

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -3,7 +3,7 @@ version: "2.1"
 dependencies: ./project-dependencies.yaml
 
 build:
-  - project: apache/incubator-kie-drools
+  - project: kiegroup/drools
     build-command:
       current: mvn --batch-mode --update-snapshots install -Dquickly
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Drools Snapshot
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-kie-drools
+          repository: kiegroup/drools
           path: drools
 
       - name: Build Drools Snapshot with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Drools Snapshot
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-kie-drools
+          repository: kiegroup/drools
           path: drools
 
       - name: Build Drools Snapshot with Maven


### PR DESCRIPTION
Issue: https://github.com/kiegroup/drools-ansible-rulebook-integration/issues/113

Hi @rgdoliveira , I'd like to solve the above issue.

When we run a GHA PR check for apache/incubator-kie-drools `10.0.x` branch, it cannot find the association with drools 10.0.x, so I added the entry here. Is this the right approach?

The GHA yml is:
https://github.com/apache/incubator-kie-drools/blob/10.0.x/.github/workflows/pr-drools-ansible.yml

Also I wonder if we can use `apache/incubator-kie-drools` instead of `kiegroup/drools` for the PR check. But I remember that you wanted to use  `kiegroup/drools` for productization needs (https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/101). Please kindly share your thought on this.

One more note, if we need to stick to  `kiegroup/drools` , `10.0.x` branch  needs to be synced with `apache/incubator-kie-drools`.
