### PR TITLE
[1.0.x][DROOLS-7635] ansible-rulebook : Raise an error when a condition compares incompatible types

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/LogUtil.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/LogUtil.java
@@ -1,0 +1,27 @@
+package org.drools.ansible.rulebook.integration.api;
+
+import java.util.Map;
+
+public class LogUtil {
+
+    private LogUtil() {
+        // utility class
+    }
+
+    // convert java class to python class
+    private static Map<Class<?>, String> convertMap = Map.of(
+            java.lang.Integer.class, "int",
+            java.lang.Boolean.class, "bool",
+            java.lang.String.class, "str",
+            java.lang.Double.class, "float",
+            java.util.List.class, "list",
+            java.util.ArrayList.class, "list",
+            java.util.Map.class, "dict",
+            java.util.LinkedHashMap.class, "dict",
+            java.util.HashMap.class, "dict"
+    );
+
+    public static String convertJavaClassToPythonClass(Class<?> javaClass) {
+        return convertMap.getOrDefault(javaClass, javaClass.getSimpleName());
+    }
+}

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/RuleGenerationContext.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/RuleGenerationContext.java
@@ -39,6 +39,8 @@ public class RuleGenerationContext {
 
     private final StackedContext<String, PrototypeDSL.PrototypePatternDef> patterns = new StackedContext<>();
 
+    private String ruleSetName;
+
     private String ruleName;
 
     private int bindingsCounter = 0;
@@ -209,11 +211,20 @@ public class RuleGenerationContext {
         this.ruleName = ruleName;
     }
 
+    public String getRuleSetName() {
+        return ruleSetName;
+    }
+
+    public void setRuleSetName(String ruleSetName) {
+        this.ruleSetName = ruleSetName;
+    }
+
     List<Rule> toExecModelRules(RulesSet rulesSet, org.drools.ansible.rulebook.integration.api.domain.Rule ansibleRule, RulesExecutionController rulesExecutionController, AtomicInteger ruleCounter) {
     	updateContextFromRule(ansibleRule);
 	    if (getRuleName() == null) {
 	        setRuleName("r_" + ruleCounter.getAndIncrement());
 	    }
+        setRuleSetName(rulesSet.getName());
 	
 	    List<org.drools.model.Rule> rules = createRules(rulesExecutionController);
 	    if (hasTemporalConstraint(ansibleRule)) {

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/conditions/MapCondition.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/conditions/MapCondition.java
@@ -218,6 +218,7 @@ public class MapCondition implements Condition {
 
     private ParsedCondition parseExpression(RuleGenerationContext ruleContext, String expressionName, Map<?, ?> expression) {
         RulebookOperator operator = decodeOperation(ruleContext, expressionName);
+        operator.setConditionContext(ruleContext, expression);
 
         if (operator instanceof ConditionFactory) {
             if (expression.get("lhs") != null) {
@@ -261,17 +262,17 @@ public class MapCondition implements Condition {
     private static RulebookOperator decodeOperation(RuleGenerationContext ruleContext, String expressionName) {
         switch (expressionName) {
             case "EqualsExpression":
-                return RulebookOperator.EQUAL;
+                return RulebookOperator.newEqual();
             case "NotEqualsExpression":
-                return RulebookOperator.NOT_EQUAL;
+                return RulebookOperator.newNotEqual();
             case "GreaterThanExpression":
-                return RulebookOperator.GREATER_THAN;
+                return RulebookOperator.newGreaterThan();
             case "GreaterThanOrEqualToExpression":
-                return RulebookOperator.GREATER_OR_EQUAL;
+                return RulebookOperator.newGreaterOrEqual();
             case "LessThanExpression":
-                return RulebookOperator.LESS_THAN;
+                return RulebookOperator.newLessThan();
             case "LessThanOrEqualToExpression":
-                return RulebookOperator.LESS_OR_EQUAL;
+                return RulebookOperator.newLessOrEqual();
             case ExistsField.EXPRESSION_NAME:
                 return ExistsField.INSTANCE;
             case ExistsField.NEGATED_EXPRESSION_NAME:

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/NegationOperator.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/NegationOperator.java
@@ -4,6 +4,8 @@ import java.util.function.BiPredicate;
 
 import org.drools.model.ConstraintOperator;
 
+import static org.drools.ansible.rulebook.integration.api.domain.constraints.RulebookConstraintOperator.isCompatibleType;
+
 public class NegationOperator implements ConstraintOperator {
 
     private final ConstraintOperator toBeNegated;
@@ -14,6 +16,16 @@ public class NegationOperator implements ConstraintOperator {
 
     @Override
     public <T, V> BiPredicate<T, V> asPredicate() {
+        if (toBeNegated instanceof RulebookConstraintOperator rulebookConstraintOperator) {
+            return (t, v) -> {
+                // if not compatible type, return false. Use the operator to log the type check error
+                if (!isCompatibleType(t, v)) {
+                    rulebookConstraintOperator.logTypeCheck(t, v);
+                    return false;
+                }
+                return !toBeNegated.asPredicate().test(t, v);
+            };
+        }
         return (t, v) -> !toBeNegated.asPredicate().test(t, v);
     }
 

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/RulebookConstraintOperator.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/RulebookConstraintOperator.java
@@ -1,0 +1,188 @@
+package org.drools.ansible.rulebook.integration.api.domain.constraints;
+
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import org.drools.ansible.rulebook.integration.api.domain.RuleGenerationContext;
+import org.drools.model.Index;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.drools.ansible.rulebook.integration.api.LogUtil.convertJavaClassToPythonClass;
+import static org.drools.model.util.OperatorUtils.areEqual;
+import static org.drools.model.util.OperatorUtils.compare;
+
+public class RulebookConstraintOperator implements RulebookOperator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RulebookConstraintOperator.class);
+
+    private Index.ConstraintType type;
+    private ConditionContext conditionContext;
+    private boolean typeCheckLogged = false;
+
+    public RulebookConstraintOperator(Index.ConstraintType type) {
+        this.type = type;
+    }
+
+    public void setConditionContext(RuleGenerationContext ruleContext, Map<?, ?> expression) {
+        this.conditionContext = new ConditionContext(ruleContext.getRuleSetName(), ruleContext.getRuleName(), expression.toString());
+    }
+
+    @Override
+    public boolean hasIndex() {
+        return true;
+    }
+
+    @Override
+    public Index.ConstraintType getIndexType() {
+        return type;
+    }
+
+    public RulebookConstraintOperator negate() {
+        switch (this.type) {
+            case FORALL_SELF_JOIN:
+            case EQUAL:
+                this.type = Index.ConstraintType.NOT_EQUAL;
+                return this;
+            case NOT_EQUAL:
+                this.type = Index.ConstraintType.EQUAL;
+                return this;
+            case GREATER_THAN:
+                this.type = Index.ConstraintType.LESS_OR_EQUAL;
+                return this;
+            case GREATER_OR_EQUAL:
+                this.type = Index.ConstraintType.LESS_THAN;
+                return this;
+            case LESS_OR_EQUAL:
+                this.type = Index.ConstraintType.GREATER_THAN;
+                return this;
+            case LESS_THAN:
+                this.type = Index.ConstraintType.GREATER_OR_EQUAL;
+                return this;
+        }
+        this.type = Index.ConstraintType.UNKNOWN;
+        return this;
+    }
+
+    public boolean canInverse() {
+        switch (this.type) {
+            case EQUAL:
+            case NOT_EQUAL:
+            case GREATER_THAN:
+            case GREATER_OR_EQUAL:
+            case LESS_THAN:
+            case LESS_OR_EQUAL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public <T, V> BiPredicate<T, V> asPredicate() {
+        final BiPredicate<T, V> predicate;
+        switch (this.type) {
+            case EQUAL:
+                predicate = (t, v) -> areEqual(t, v);
+                break;
+            case NOT_EQUAL:
+                predicate = (t, v) -> !areEqual(t, v);
+                break;
+            case GREATER_THAN:
+                predicate = (t,v) -> t != null && compare(t, v) > 0;
+                break;
+            case GREATER_OR_EQUAL:
+                predicate = (t,v) -> t != null && compare(t, v) >= 0;
+                break;
+            case LESS_THAN:
+                predicate = (t,v) -> t != null && compare(t, v) < 0;
+                break;
+            case LESS_OR_EQUAL:
+                predicate = (t,v) -> t != null && compare(t, v) <= 0;
+                break;
+            default:
+                throw new UnsupportedOperationException("Cannot convert " + this + " into a predicate");
+        }
+        return (t, v) -> predicateWithTypeCheck(t, v, predicate);
+    }
+
+    private <T, V> boolean predicateWithTypeCheck(T t, V v, BiPredicate<T, V> predicate) {
+        if (t == null
+                || v == null
+                || t instanceof Number && v instanceof Number
+                || t.getClass() == v.getClass()) {
+            return predicate.test(t, v);
+        } else {
+            if (!typeCheckLogged) {
+                LOG.error("Cannot compare values of different types: {} and {}. RuleSet: {}. RuleName: {}. Condition: {}",
+                          convertJavaClassToPythonClass(t.getClass()),
+                          convertJavaClassToPythonClass(v.getClass()),
+                          conditionContext.getRuleSet(), conditionContext.getRuleName(), conditionContext.getConditionExpression());
+                typeCheckLogged = true; // Log only once per constraint
+            }
+            return false; // Different types are never equal
+        }
+    }
+
+    public RulebookConstraintOperator inverse() {
+        switch (this.type) {
+            case GREATER_THAN:
+                this.type = Index.ConstraintType.LESS_THAN;
+                return this;
+            case GREATER_OR_EQUAL:
+                this.type =  Index.ConstraintType.LESS_OR_EQUAL;
+                return this;
+            case LESS_THAN:
+                this.type = Index.ConstraintType.GREATER_THAN;
+                return this;
+            case LESS_OR_EQUAL:
+                this.type = Index.ConstraintType.GREATER_OR_EQUAL;
+                return this;
+            default:
+                return this;
+        }
+    }
+
+    public boolean isComparison() {
+        return isAscending() || isDescending();
+    }
+
+    public boolean isAscending() {
+        return this.type == Index.ConstraintType.GREATER_THAN || this.type == Index.ConstraintType.GREATER_OR_EQUAL;
+    }
+
+    public boolean isDescending() {
+        return this.type == Index.ConstraintType.LESS_THAN || this.type == Index.ConstraintType.LESS_OR_EQUAL;
+    }
+
+    private class ConditionContext {
+
+        private String ruleSet;
+        private String ruleName;
+        private String conditionExpression;
+
+        public ConditionContext(String ruleSet, String ruleName, String conditionExpression) {
+            this.ruleSet = ruleSet;
+            this.ruleName = ruleName;
+            this.conditionExpression = conditionExpression;
+        }
+
+        public String getRuleSet() {
+            return ruleSet;
+        }
+
+        public String getRuleName() {
+            return ruleName;
+        }
+
+        public String getConditionExpression() {
+            return conditionExpression;
+        }
+    }
+
+    @Override
+    public String toString() {
+        // works for node sharing
+        return type.toString();
+    }
+}

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/RulebookOperator.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/domain/constraints/RulebookOperator.java
@@ -1,9 +1,11 @@
 package org.drools.ansible.rulebook.integration.api.domain.constraints;
 
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import org.drools.ansible.rulebook.integration.api.domain.RuleGenerationContext;
 import org.drools.model.ConstraintOperator;
 import org.drools.model.Index;
-
-import java.util.function.BiPredicate;
 
 public interface RulebookOperator extends ConstraintOperator {
 
@@ -19,38 +21,35 @@ public interface RulebookOperator extends ConstraintOperator {
         return this;
     }
 
-    RulebookOperator EQUAL = new OperatorWrapper(Index.ConstraintType.EQUAL);
-    RulebookOperator NOT_EQUAL = new OperatorWrapper(Index.ConstraintType.NOT_EQUAL);
-    RulebookOperator GREATER_THAN = new OperatorWrapper(Index.ConstraintType.GREATER_THAN);
-    RulebookOperator GREATER_OR_EQUAL = new OperatorWrapper(Index.ConstraintType.GREATER_OR_EQUAL);
-    RulebookOperator LESS_THAN = new OperatorWrapper(Index.ConstraintType.LESS_THAN);
-    RulebookOperator LESS_OR_EQUAL = new OperatorWrapper(Index.ConstraintType.LESS_OR_EQUAL);
+    static RulebookOperator newEqual() {
+        return new RulebookConstraintOperator(Index.ConstraintType.EQUAL);
+    }
 
-    class OperatorWrapper implements RulebookOperator {
-        private final Index.ConstraintType delegate;
+    static RulebookOperator newNotEqual() {
+        return new RulebookConstraintOperator(Index.ConstraintType.NOT_EQUAL);
+    }
 
-        public OperatorWrapper(Index.ConstraintType delegate) {
-            this.delegate = delegate;
-        }
+    static RulebookOperator newGreaterThan() {
+        return new RulebookConstraintOperator(Index.ConstraintType.GREATER_THAN);
+    }
 
-        @Override
-        public <T, V> BiPredicate<T, V> asPredicate() {
-            return delegate.asPredicate();
-        }
+    static RulebookOperator newGreaterOrEqual() {
+        return new RulebookConstraintOperator(Index.ConstraintType.GREATER_OR_EQUAL);
+    }
 
-        @Override
-        public boolean canInverse() {
-            return delegate.canInverse();
-        }
+    static RulebookOperator newLessThan() {
+        return new RulebookConstraintOperator(Index.ConstraintType.LESS_THAN);
+    }
 
-        @Override
-        public RulebookOperator inverse() {
-            return new OperatorWrapper(delegate.inverse());
-        }
+    static RulebookOperator newLessOrEqual() {
+        return new RulebookConstraintOperator(Index.ConstraintType.LESS_OR_EQUAL);
+    }
 
-        @Override
-        public ConstraintOperator asConstraintOperator() {
-            return delegate;
+    default void setConditionContext(RuleGenerationContext ruleContext, Map<?, ?> expression) {
+        if (this instanceof RulebookConstraintOperator rulebookConstraintOperator) {
+            rulebookConstraintOperator.setConditionContext(ruleContext, expression);
+        } else {
+            // do nothing
         }
     }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/StringPrintStream.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/StringPrintStream.java
@@ -1,0 +1,36 @@
+package org.drools.ansible.rulebook.integration.api;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StringPrintStream extends PrintStream {
+
+    public static final String LINE_SEP = System.getProperty("line.separator");
+    PrintStream other;
+    List<String> stringList = new ArrayList<>();
+
+    public StringPrintStream(PrintStream ps) {
+        super(ps);
+        other = ps;
+    }
+
+    public void print(String s) {
+        other.print(s);
+        stringList.add(s);
+    }
+
+    public void println(String s) {
+        other.println(s);
+        stringList.add(s);
+    }
+
+    public void println(Object o) {
+        other.println(o);
+        stringList.add(o.toString());
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+}

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/TypeMismatchTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/TypeMismatchTest.java
@@ -40,7 +40,7 @@ public class TypeMismatchTest {
         stringPrintStream.getStringList().clear();
     }
 
-    public static final String JSON1 =
+    public static final String JSON_MAP_STRING =
             """
                     {
                         "name": "ruleSet1",
@@ -107,10 +107,10 @@ public class TypeMismatchTest {
 
     @Test
     public void mapAndString() {
-        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON1);
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_MAP_STRING);
 
-        // incoming event.mera.headers is a map, not a string
-        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\"}} } }").join();
+        // incoming event.meta.headers is a map, not a string
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\" } } }").join();
         // When comparing mismatched types, the rule should not match (even r2). Logs error for 2 rules.
         assertNumberOfErrorLogs(2);
         assertThat(stringPrintStream.getStringList())
@@ -125,7 +125,7 @@ public class TypeMismatchTest {
         assertEquals(0, matchedRules.size());
 
         // One more time
-        matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"25\"}} } }").join();
+        matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"25\" } } }").join();
         // not firing. Don't log errors again.
         assertNumberOfErrorLogs(2);
         assertEquals(0, matchedRules.size());
@@ -133,7 +133,7 @@ public class TypeMismatchTest {
         rulesExecutor.dispose();
     }
 
-    public static final String JSON2 =
+    public static final String JSON_STRING_INTEGER =
             """
                     {
                         "name": "ruleSet1",
@@ -172,9 +172,9 @@ public class TypeMismatchTest {
 
     @Test
     public void stringAndInteger() {
-        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON2);
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_STRING_INTEGER);
 
-        // incoming event.i is a string, not a integer
+        // incoming event.i is a String, not an Integer
         List<Match> matchedRules = rulesExecutor.processEvents("{ \"i\": \"1\" }").join();
         assertNumberOfErrorLogs(1);
         assertThat(stringPrintStream.getStringList())
@@ -290,7 +290,7 @@ public class TypeMismatchTest {
                            .filter(constraint -> constraint.getExprId().equals("expr:i:EQUAL:1"))
                            .count()).isEqualTo(1);
 
-        // i is a string, not an integer
+        // i is a String, not an Integer
         List<Match> matchedRules = rulesExecutor.processEvents("{ \"i\": \"1\", \"j\": 1 }").join();
         assertNumberOfErrorLogs(1);
         assertEquals(0, matchedRules.size());
@@ -321,5 +321,297 @@ public class TypeMismatchTest {
 
     private static void assertNumberOfErrorLogs(int expected) {
         assertThat(stringPrintStream.getStringList().stream().filter(s -> s.contains("ERROR")).count()).isEqualTo(expected);
+    }
+
+    public static final String JSON_ALPHA_INDEX =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "meta.headers"
+                                                     },
+                                                     "rhs": {
+                                                         "String": "AAA"
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             },
+                             {
+                                 "Rule": {
+                                     "name": "r2",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "meta.headers"
+                                                     },
+                                                     "rhs": {
+                                                         "String": "BBB"
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             },
+                             {
+                                 "Rule": {
+                                     "name": "r3",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "meta.headers"
+                                                     },
+                                                     "rhs": {
+                                                         "String": "CCC"
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void alphaIndex() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_ALPHA_INDEX);
+
+        // incoming event.meta.headers is a map, not a string
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\" } } }").join();
+        // When alpha index is effective (= more than 3 Equals for the same property with literal values), constraint is not evaluated, so no error log. Just don't match.
+        assertNumberOfErrorLogs(0);
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    public static final String JSON_BETA_INDEX =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                        "AllCondition": [
+                                            {
+                                                "EqualsExpression": {
+                                                    "lhs": {
+                                                        "Event": "mydata"
+                                                    },
+                                                    "rhs": {
+                                                        "String": "AAA"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "EqualsExpression": {
+                                                    "lhs": {
+                                                        "Event": "meta.headers"
+                                                    },
+                                                    "rhs": {
+                                                        "Events": "m_0.mydata"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void betaIndex() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_BETA_INDEX);
+
+        // incoming event.meta.headers is a map, not a string
+        rulesExecutor.processEvents("{ \"mydata\": \"AAA\" }").join();
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\" } } }").join();
+
+        // When beta index is effective (= comparing 2 events properties with Equals), constraint is not evaluated, so no error log. Just doesn't match.
+        assertNumberOfErrorLogs(0);
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    public static final String JSON_NEGATE =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "NegateExpression": {
+                                                     "EqualsExpression": {
+                                                         "lhs": {
+                                                             "Event": "meta.headers"
+                                                         },
+                                                         "rhs": {
+                                                             "String": "Hello Testing World"
+                                                         }
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void negation() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_NEGATE);
+
+        // incoming event.meta.headers is a map, not a string
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\"} } }").join();
+        // When comparing mismatched types, the rule should not match, even with negation. Logs error for 1 rule.
+        assertNumberOfErrorLogs(1);
+        assertThat(stringPrintStream.getStringList())
+                .anyMatch(s -> s.contains("Cannot compare values of different types: dict and str." +
+                                                  " RuleSet: ruleSet1." +
+                                                  " RuleName: r1." +
+                                                  " Condition: {lhs={Event=meta.headers}, rhs={String=Hello Testing World}}"));
+
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    public static final String JSON_ANY =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                         "AnyCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                        "Event": "i"
+                                                     },
+                                                     "rhs": {
+                                                        "Integer": 1
+                                                     }
+                                                 }
+                                             },
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                        "Event": "j"
+                                                     },
+                                                     "rhs": {
+                                                        "Integer": 1
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void any() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_ANY);
+
+        rulesExecutor.processEvents("{ \"i\": \"AAA\"}").join();
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"j\": 1 }").join();
+        assertNumberOfErrorLogs(1);
+        assertThat(stringPrintStream.getStringList())
+                .anyMatch(s -> s.contains("Cannot compare values of different types: str and int." +
+                                                  " RuleSet: ruleSet1." +
+                                                  " RuleName: r1." +
+                                                  " Condition: {lhs={Event=i}, rhs={Integer=1}}"));
+
+        // j == 1 matches, so the rule should match
+        assertEquals(1, matchedRules.size());
+
+        rulesExecutor.dispose();
     }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/TypeMismatchTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/TypeMismatchTest.java
@@ -1,0 +1,325 @@
+package org.drools.ansible.rulebook.integration.api;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.base.common.NetworkNode;
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.ObjectSink;
+import org.drools.kiesession.rulebase.InternalKnowledgeBase;
+import org.drools.modelcompiler.constraints.LambdaConstraint;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.rule.Match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class TypeMismatchTest {
+
+    // For logging assertion
+    static PrintStream originalOut = System.out;
+    static StringPrintStream stringPrintStream = new StringPrintStream(System.out);
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setOut(stringPrintStream);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.setOut(originalOut);
+    }
+
+    @Before
+    public void before() {
+        stringPrintStream.getStringList().clear();
+    }
+
+    public static final String JSON1 =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "meta.headers"
+                                                     },
+                                                     "rhs": {
+                                                         "String": "Hello Testing World"
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             },
+                             {
+                                 "Rule": {
+                                     "name": "r2",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "NotEqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "meta.headers"
+                                                     },
+                                                     "rhs": {
+                                                         "String": "Hello Testing World"
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void mapAndString() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON1);
+
+        // incoming event.mera.headers is a map, not a string
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"36\"}} } }").join();
+        // When comparing mismatched types, the rule should not match (even r2). Logs error for 2 rules.
+        assertNumberOfErrorLogs(2);
+        assertThat(stringPrintStream.getStringList())
+                .anyMatch(s -> s.contains("Cannot compare values of different types: dict and str." +
+                                                  " RuleSet: ruleSet1." +
+                                                  " RuleName: r1." +
+                                                  " Condition: {lhs={Event=meta.headers}, rhs={String=Hello Testing World}}"))
+                .anyMatch(s -> s.contains("Cannot compare values of different types: dict and str." +
+                                                  " RuleSet: ruleSet1." +
+                                                  " RuleName: r2." +
+                                                  " Condition: {lhs={Event=meta.headers}, rhs={String=Hello Testing World}}"));
+        assertEquals(0, matchedRules.size());
+
+        // One more time
+        matchedRules = rulesExecutor.processEvents("{ \"meta\": {\"headers\": {\"Content-Length\": \"25\"}} } }").join();
+        // not firing. Don't log errors again.
+        assertNumberOfErrorLogs(2);
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    public static final String JSON2 =
+            """
+                    {
+                        "name": "ruleSet1",
+                        "rules": [
+                             {
+                                 "Rule": {
+                                     "name": "r1",
+                                     "condition": {
+                                         "AllCondition": [
+                                             {
+                                                 "EqualsExpression": {
+                                                     "lhs": {
+                                                         "Event": "i"
+                                                     },
+                                                     "rhs": {
+                                                         "Integer": 1
+                                                     }
+                                                 }
+                                             }
+                                         ]
+                                     },
+                                     "actions": [
+                                         {
+                                             "Action": {
+                                                 "action": "debug",
+                                                 "action_args": {}
+                                             }
+                                         }
+                                     ],
+                                     "enabled": true
+                                 }
+                             }
+                         ]
+                    }
+                    """;
+
+    @Test
+    public void stringAndInteger() {
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON2);
+
+        // incoming event.i is a string, not a integer
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"i\": \"1\" }").join();
+        assertNumberOfErrorLogs(1);
+        assertThat(stringPrintStream.getStringList())
+                .anyMatch(s -> s.contains("Cannot compare values of different types: str and int." +
+                                                  " RuleSet: ruleSet1." +
+                                                  " RuleName: r1." +
+                                                  " Condition: {lhs={Event=i}, rhs={Integer=1}}"));
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    @Test
+    public void typeMismatchWithNodeSharing() {
+        String json =
+                """
+                        {
+                            "rules": [
+                                {
+                                    "Rule": {
+                                        "name": "r1",
+                                        "condition": {
+                                            "AllCondition": [
+                                                {
+                                                    "AndExpression": {
+                                                        "lhs": {
+                                                            "EqualsExpression": {
+                                                                "lhs": {
+                                                                    "Event": "i"
+                                                                },
+                                                                "rhs": {
+                                                                    "Integer": 1
+                                                                }
+                                                            }
+                                                        },
+                                                        "rhs": {
+                                                            "EqualsExpression": {
+                                                                "lhs": {
+                                                                    "Event": "j"
+                                                                },
+                                                                "rhs": {
+                                                                    "Integer": 1
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "actions": [
+                                            {
+                                                "Action": {
+                                                    "action": "debug",
+                                                    "action_args": {}
+                                                }
+                                            }
+                                        ],
+                                        "enabled": true
+                                    }
+                                },
+                                {
+                                    "Rule": {
+                                        "name": "r2",
+                                        "condition": {
+                                            "AllCondition": [
+                                                {
+                                                    "AndExpression": {
+                                                        "lhs": {
+                                                            "EqualsExpression": {
+                                                                "lhs": {
+                                                                    "Event": "i"
+                                                                },
+                                                                "rhs": {
+                                                                    "Integer": 1
+                                                                }
+                                                            }
+                                                        },
+                                                        "rhs": {
+                                                            "EqualsExpression": {
+                                                                "lhs": {
+                                                                    "Event": "j"
+                                                                },
+                                                                "rhs": {
+                                                                    "Integer": 2
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "actions": [
+                                            {
+                                                "Action": {
+                                                    "action": "debug",
+                                                    "action_args": {}
+                                                }
+                                            }
+                                        ],
+                                        "enabled": true
+                                    }
+                                }
+                            ]
+                        }
+                        """;
+
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(json);
+        KieBase kieBase = rulesExecutor.asKieSession().getKieBase();
+        List<AlphaNode> alphaNodes = collectAlphaNodes(kieBase);
+        // assert node sharing
+        assertThat(alphaNodes.stream()
+                           .map(node -> ((LambdaConstraint) node.getConstraint()).getEvaluator().getConstraint())
+                           .filter(constraint -> constraint.getExprId().equals("expr:i:EQUAL:1"))
+                           .count()).isEqualTo(1);
+
+        // i is a string, not an integer
+        List<Match> matchedRules = rulesExecutor.processEvents("{ \"i\": \"1\", \"j\": 1 }").join();
+        assertNumberOfErrorLogs(1);
+        assertEquals(0, matchedRules.size());
+
+        rulesExecutor.dispose();
+    }
+
+    private List<AlphaNode> collectAlphaNodes(KieBase kieBase) {
+        List<AlphaNode> alphaNodes = new ArrayList<>();
+        ((InternalKnowledgeBase) kieBase).getRete().getObjectTypeNodes().forEach(otn -> {
+            ObjectSink[] sinks = otn.getObjectSinkPropagator().getSinks();
+            collectAlphaNodes(sinks, alphaNodes);
+        });
+        return alphaNodes;
+    }
+
+    private static void collectAlphaNodes(NetworkNode[] sinks, List<AlphaNode> alphaNodes) {
+        if (sinks == null) {
+            return;
+        }
+        for (NetworkNode sink : sinks) {
+            if (sink instanceof AlphaNode alphaNode) {
+                alphaNodes.add(alphaNode);
+            }
+            collectAlphaNodes(sink.getSinks(), alphaNodes);
+        }
+    }
+
+    private static void assertNumberOfErrorLogs(int expected) {
+        assertThat(stringPrintStream.getStringList().stream().filter(s -> s.contains("ERROR")).count()).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
This is a backport PR of https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/114 and https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/117 for 1.0.x

DO-NOT-MERGE until https://github.com/kiegroup/drools/pull/81 will be merged or we will decide to change the depending drools branch/version (which would require an update on this PR as well).

Until then, CI would fail with compilation errors.