### PR TITLE
[DROOLS-7645] Add baseLevelMemory to SessionStats

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/RulesExecutorSession.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/RulesExecutorSession.java
@@ -46,6 +46,7 @@ public class RulesExecutorSession {
         this.sessionStatsCollector = new SessionStatsCollector(id);
         this.rulesSetEventStructure = new RulesSetEventStructure(rulesSet);
 
+        this.sessionStatsCollector.registerBaseLevelMemory(); // initial used memory after kbase/ksession creation
         initClock();
     }
 

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStats.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStats.java
@@ -37,6 +37,8 @@ public class SessionStats {
     private final String lastRuleFiredAt;
     private final String lastEventReceivedAt;
 
+    private final long baseLevelMemory;
+
     public SessionStats(SessionStatsCollector stats, RulesExecutorSession session, boolean disposing) {
         this.start = stats.getStart().toString();
         this.end = disposing ? Instant.now().toString() : null;
@@ -61,11 +63,12 @@ public class SessionStats {
         this.lastRuleFired = stats.getLastRuleFired();
         this.lastRuleFiredAt = stats.getLastRuleFiredTime() < 0 ? null : Instant.ofEpochMilli(stats.getLastRuleFiredTime()).toString();
         this.lastEventReceivedAt = stats.getLastEventReceivedTime() < 0 ? null : Instant.ofEpochMilli(stats.getLastEventReceivedTime()).toString();
+        this.baseLevelMemory = stats.getBaseLevelMemory();
     }
 
     public SessionStats(String start, String end, String lastClockTime, int clockAdvanceCount, int numberOfRules, int numberOfDisabledRules, int rulesTriggered, int eventsProcessed,
                         int eventsMatched, int eventsSuppressed, int permanentStorageCount, int permanentStorageSize, int asyncResponses, int bytesSentOnAsync,
-                        long sessionId, String ruleSetName, String lastRuleFired, String lastRuleFiredAt, String lastEventReceivedAt) {
+                        long sessionId, String ruleSetName, String lastRuleFired, String lastRuleFiredAt, String lastEventReceivedAt, long baseLevelMemory) {
         this.start = start;
         this.end = end;
         this.lastClockTime = lastClockTime;
@@ -85,6 +88,7 @@ public class SessionStats {
         this.lastRuleFired = lastRuleFired;
         this.lastRuleFiredAt = lastRuleFiredAt;
         this.lastEventReceivedAt = lastEventReceivedAt;
+        this.baseLevelMemory = baseLevelMemory;
     }
 
     @Override
@@ -109,6 +113,7 @@ public class SessionStats {
                 ", lastRuleFired='" + lastRuleFired + '\'' +
                 ", lastRuleFiredAt='" + lastRuleFiredAt + '\'' +
                 ", lastEventReceivedAt='" + lastEventReceivedAt + '\'' +
+                ", baseLevelMemory=" + baseLevelMemory +
                 ", usedMemory='" + getUsedMemory() + '\'' +
                 ", maxAvailableMemory='" + getMaxAvailableMemory() + '\'' +
                 '}';
@@ -198,6 +203,10 @@ public class SessionStats {
         return MemoryMonitorUtil.getMaxAvailableMemory();
     }
 
+    public long getBaseLevelMemory() {
+        return baseLevelMemory;
+    }
+
     public static SessionStats aggregate(SessionStats stats1, SessionStats stats2) {
         String lastRuleFired = null;
         String lastRuleFiredAt = null;
@@ -231,7 +240,8 @@ public class SessionStats {
                 stats1.getRuleSetName().equals(stats2.getRuleSetName()) ? stats1.getRuleSetName() : "",
                 lastRuleFired,
                 lastRuleFiredAt,
-                isInstant1Last(stats1.getLastEventReceivedAt(), stats2.getLastEventReceivedAt()) ? stats1.getLastEventReceivedAt() : stats2.getLastEventReceivedAt()
+                isInstant1Last(stats1.getLastEventReceivedAt(), stats2.getLastEventReceivedAt()) ? stats1.getLastEventReceivedAt() : stats2.getLastEventReceivedAt(),
+                Math.max(stats1.baseLevelMemory, stats2.baseLevelMemory)
         );
     }
 

--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStatsCollector.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/SessionStatsCollector.java
@@ -34,6 +34,7 @@ public class SessionStatsCollector {
 
     private int clockAdvanceCount;
 
+    private long baseLevelMemory;
 
     static {
         String envValue = System.getenv("DROOLS_LOG_DELAY");
@@ -92,6 +93,10 @@ public class SessionStatsCollector {
         return clockAdvanceCount;
     }
 
+    public long getBaseLevelMemory() {
+        return baseLevelMemory;
+    }
+
     public void registerMatch(RulesExecutorSession session, Match match) {
         rulesTriggered++;
         lastRuleFired = match.getRule().getName();
@@ -118,5 +123,10 @@ public class SessionStatsCollector {
 
     public void registerClockAdvance(long amount, TimeUnit unit) {
         clockAdvanceCount++;
+    }
+
+    public void registerBaseLevelMemory() {
+        System.gc(); // NOSONAR
+        this.baseLevelMemory = MemoryMonitorUtil.getUsedMemory();
     }
 }

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/SessionStatsTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/SessionStatsTest.java
@@ -7,6 +7,7 @@ import org.kie.api.runtime.rule.Match;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -101,5 +102,47 @@ public class SessionStatsTest {
 
         SessionStats disposeStats = rulesExecutor.dispose();
         assertNotNull( disposeStats.getEnd() );
+    }
+
+    @Test
+    public void baseLevelMemory() {
+        String rule =
+                """
+                {
+                    "rules": [
+                            {
+                                "Rule": {
+                                    "name": "R1",
+                                    "condition": {
+                                        "AllCondition": [
+                                            {
+                                                "EqualsExpression": {
+                                                    "lhs": {
+                                                        "Event": "i"
+                                                    },
+                                                    "rhs": {
+                                                        "Integer": 1
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                }
+                """;
+
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(rule);
+
+        SessionStats beforeFiringStats = rulesExecutor.getSessionStats();
+
+        long baseLevelMemory = beforeFiringStats.getBaseLevelMemory();
+        assertNotEquals(-1, baseLevelMemory);
+
+        rulesExecutor.processEvents("{ \"i\": 1 }").join();
+        SessionStats statsAfterProcessEvent = rulesExecutor.getSessionStats();
+
+        assertEquals(baseLevelMemory, statsAfterProcessEvent.getBaseLevelMemory());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7645

Add "baseLevelMemory" to SessionStats, which has the used memory size right after the ruleset loading (= kbase/ksession creation).
