### PR TITLE
align project-dependences.yaml with drools 9.103.x-prod

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -5,7 +5,7 @@ dependencies:
       dependant:
         default:
           # whenever drools branch changes, please update .ci/jenkins/Jenkinsfile.prod.nightly as well if needed
-          - source: 9.102.x-prod
+          - source: 9.103.x-prod
             target: 1.0.x
 
   - project: kiegroup/drools-ansible-rulebook-integration
@@ -15,4 +15,4 @@ dependencies:
       dependencies:
         default:
           - source: 1.0.x
-            target: 9.102.x-prod
+            target: 9.103.x-prod


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/137
- https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/136