### PR TITLE
[drools-ansible-rulebook-integration-140] Memory Leak on dormant matches

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MemoryLeakTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MemoryLeakTest.java
@@ -2,6 +2,7 @@ package org.drools.ansible.rulebook.integration.api;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.kie.api.runtime.rule.Match;
@@ -42,6 +43,8 @@ public class MemoryLeakTest {
 
     public static final String EVENT_24KB_UNMATCH = "{\"i\":5,\"data\":\"" + "A".repeat(24 * 1024) + "\"}";
 
+    @Disabled("disabled by default as this could be unstable." +
+            " Also this test may flood the logs with DEBUG messages (SimpleLogger cannot change the log level dynamically)")
     @Test
     @Timeout(120)
     void testMemoryLeakWithUnmatchEvents() {
@@ -108,6 +111,8 @@ public class MemoryLeakTest {
 
     public static final String EVENT_24KB = "{\"i\":1,\"data\":\"" + "A".repeat(24 * 1024) + "\"}";
 
+    @Disabled("disabled by default as this could be unstable." +
+            " Also this test may flood the logs with DEBUG messages (SimpleLogger cannot change the log level dynamically)")
     @Test
     @Timeout(120)
     public void testMemoryLeakWithMatchingEvents() {

--- a/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MemoryLeakTest.java
+++ b/drools-ansible-rulebook-integration-api/src/test/java/org/drools/ansible/rulebook/integration/api/MemoryLeakTest.java
@@ -1,10 +1,16 @@
 package org.drools.ansible.rulebook.integration.api;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.kie.api.runtime.rule.Match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class MemoryLeakTest {
-    public static final String JSON1 =
+    public static final String JSON_TTL =
             """
             {
                 "rules": [
@@ -33,13 +39,12 @@ public class MemoryLeakTest {
             }
             """;
 
-    @Disabled("This test is to check for memory leaks. It should be run manually and not as part of the build.")
     @Test
     void testMemoryLeakWithUnmatchEvents() {
         // If you set a short time for default_events_ttl, you can observe expiring jobs
 
         System.setProperty("org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration", "INFO");
-        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON1);
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_TTL);
 
         for (int i = 0; i < 2000000; i++) {
             rulesExecutor.processEvents( "{ \"i\": 5 }").join(); // not match
@@ -55,5 +60,70 @@ public class MemoryLeakTest {
             }
         }
         rulesExecutor.dispose();
+    }
+
+    public static final String JSON_PLAIN =
+            """
+            {
+                "rules": [
+                        {
+                            "Rule": {
+                                "condition": {
+                                    "AllCondition": [
+                                        {
+                                            "EqualsExpression": {
+                                                "lhs": {
+                                                    "Event": "i"
+                                                },
+                                                "rhs": {
+                                                    "Integer": 1
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "enabled": true,
+                                "name": null
+                            }
+                        }
+                    ]
+            }
+            """;
+
+    public static final String EVENT_24KB = "{\"i\":1,\"data\":\"" + "A".repeat(24 * 1024) + "\"}";
+
+    @Test
+    public void testMemoryLeakWithMatchingEvents() {
+        System.setProperty("org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration", "INFO");
+        RulesExecutor rulesExecutor = RulesExecutorFactory.createFromJson(JSON_PLAIN);
+        System.gc();
+        long baseMemory = rulesExecutor.getSessionStats().getUsedMemory();
+        try {
+            for (int i = 0; i < 10000; i++) {
+                // The 24KB isn’t the condition to reproduce; it’s just to make checking the heap size easier.
+                List<Match> matches = rulesExecutor.processEvents(EVENT_24KB).join();
+                assertThat(matches).hasSize(1);
+
+                if (i % 20 == 0) {
+                    System.out.println("Processed " + i + " events. Calling GC");
+                    System.gc();
+                    System.out.println("  usedMemory = " + rulesExecutor.getSessionStats().getUsedMemory());
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                }
+            }
+
+            // Allow some memory for the processing overhead
+            // The memoryOverhead may not be a critical threshold. If the test fails, you may consider increasing it unless it's not a memory leak.
+            long memoryOverhead = 10 * 1000 * 1024; // 10 MB
+            System.gc();
+            long usedMemory = rulesExecutor.getSessionStats().getUsedMemory();
+            assertThat(usedMemory).isLessThan(baseMemory + memoryOverhead);
+        } finally {
+            rulesExecutor.dispose();
+        }
     }
 }


### PR DESCRIPTION
Issue:
- https://github.com/kiegroup/drools-ansible-rulebook-integration/issues/140

Test only.

It takes a few minutes to finish, but you can easily confirm the heap trend via STDOUT.

```
Processed 0 events. Calling GC
  usedMemory = 13958840
Processed 20 events. Calling GC
  usedMemory = 14653592
Processed 40 events. Calling GC
  usedMemory = 14990160
Processed 60 events. Calling GC
  usedMemory = 15499176
Processed 80 events. Calling GC
  usedMemory = 16003368
...
```