### PR TITLE
[1.0.x] [DROOLS-7647] Memory Leak with matching events after 1.0.7-SNAPSHOT

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -29,7 +29,7 @@ pipeline{
           script {
             // Fetch versions from pom if not provided
             env.PRODUCT_VERSION = "${PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools-ansible-rulebook-integration')}"
-            env.DROOLS_PRODUCT_VERSION = "${DROOLS_PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools', '9.103.x-prod')}"
+            env.DROOLS_PRODUCT_VERSION = "${DROOLS_PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools', '9.103.x-prod-ansible')}"
           }
 
           sh 'printenv'

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -5,7 +5,7 @@ dependencies:
       dependant:
         default:
           # whenever drools branch changes, please update .ci/jenkins/Jenkinsfile.prod.nightly as well if needed
-          - source: 9.103.x-prod
+          - source: 9.103.x-prod-ansible
             target: 1.0.x
 
   - project: kiegroup/drools-ansible-rulebook-integration
@@ -15,4 +15,4 @@ dependencies:
       dependencies:
         default:
           - source: 1.0.x
-            target: 9.103.x-prod
+            target: 9.103.x-prod-ansible

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,14 +17,14 @@ jobs:
           distribution: 'adopt'
 
 
-      - name: Checkout Drools 9.103.0
+      - name: Checkout Drools 9.103.1
         uses: actions/checkout@v3
         with:
           repository: kiegroup/drools
           path: drools
-          ref: 9.103.x-prod
+          ref: 9.103.x-prod-ansible
 
-      - name: Build Drools 9.103.0 with Maven
+      - name: Build Drools 9.103.1 with Maven
         run: cd drools && mvn --batch-mode --update-snapshots install -Dquickly && cd ..
 
       - uses: actions/checkout@v3

--- a/drools-ansible-rulebook-integration-api/pom.xml
+++ b/drools-ansible-rulebook-integration-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-benchmark/pom.xml
+++ b/drools-ansible-rulebook-integration-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-benchmark</artifactId>

--- a/drools-ansible-rulebook-integration-core-rest/pom.xml
+++ b/drools-ansible-rulebook-integration-core-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-core-rest</artifactId>

--- a/drools-ansible-rulebook-integration-main/pom.xml
+++ b/drools-ansible-rulebook-integration-main/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-protoextractor/pom.xml
+++ b/drools-ansible-rulebook-integration-protoextractor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-runtime/pom.xml
+++ b/drools-ansible-rulebook-integration-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-runtime</artifactId>

--- a/drools-ansible-rulebook-integration-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   
   <groupId>org.drools</groupId>
   <artifactId>drools-ansible-rulebook-integration</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>1.0.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -30,7 +30,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.drools>9.103.0</version.drools> <!-- kiegroup/drools 9.103.x-prod branch-->
+    <version.drools>9.103.1</version.drools> <!-- kiegroup/drools 9.103.x-prod-ansible branch-->
     <version.org.antlr4>4.13.0</version.org.antlr4><!-- antlr4 (and exec:java) maven plugins not managed in drools-build-parent -->
     <version.jmh>1.35</version.jmh>
   </properties>


### PR DESCRIPTION
- Use drools 9.103.1 which contains the fix
- Bump to 1.0.9-SNAPSHOT

Manually confirmed that `load_test_all.sh` gives stable results, so the memory leak is fixed.