### PR TITLE
Gha memory leak test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   drools-ansible:
+    if: false
     concurrency:
       group: pr-drools_ansible_${{ matrix.os }}_${{ matrix.java-version }}_${{ matrix.maven-version }}_${{ github.head_ref }}
       cancel-in-progress: true
@@ -71,7 +72,8 @@ jobs:
 
       - name: Run load tests and analyze memory leaks
         run: |
-          cd drools-ansible-rulebook-integration-main
+          pwd
+          cd kiegroup_drools-ansible-rulebook-integration/drools-ansible-rulebook-integration-main
           chmod +x load_test_all.sh
           ./load_test_all.sh
 
@@ -80,5 +82,5 @@ jobs:
         if: always()
         with:
           name: memory-leak-test-results
-          path: drools-ansible-rulebook-integration-main/result_all.txt
+          path: kiegroup_drools-ansible-rulebook-integration/drools-ansible-rulebook-integration-main/result_all.txt
           retention-days: 30

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   drools-ansible:
-    if: false
     concurrency:
       group: pr-drools_ansible_${{ matrix.os }}_${{ matrix.java-version }}_${{ matrix.maven-version }}_${{ github.head_ref }}
       cancel-in-progress: true
@@ -61,8 +60,7 @@ jobs:
           java-version: '17'
           maven-version: '3.9.3'
 
-      # Run MemoryLeakTest
-      - name: Build Chain
+      - name: Build Chain running MemoryLeakTest
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
           BUILD_MVN_OPTS_CURRENT: '-Pmemoryleak-tests'
@@ -72,7 +70,6 @@ jobs:
 
       - name: Run load tests and analyze memory leaks
         run: |
-          pwd
           cd kiegroup_drools-ansible-rulebook-integration/drools-ansible-rulebook-integration-main
           chmod +x load_test_all.sh
           ./load_test_all.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,3 +45,40 @@ jobs:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/drools-ansible-rulebook-integration/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  memory-leak-test:
+    name: Memory Leak Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clean Disk Space
+        uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
+
+      - name: Java and Maven Setup
+        uses: kiegroup/kie-ci/.ci/actions/maven@main
+        with:
+          java-version: '17'
+          maven-version: '3.9.3'
+
+      # Run MemoryLeakTest
+      - name: Build Chain
+        uses: kiegroup/kie-ci/.ci/actions/build-chain@main
+        env:
+          BUILD_MVN_OPTS_CURRENT: '-Pmemoryleak-tests'
+        with:
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/drools-ansible-rulebook-integration/${BRANCH:main}/.ci/pull-request-config.yaml
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run load tests and analyze memory leaks
+        run: |
+          cd drools-ansible-rulebook-integration-main
+          chmod +x load_test_all.sh
+          ./load_test_all.sh
+
+      - name: Upload load test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: memory-leak-test-results
+          path: drools-ansible-rulebook-integration-main/result_all.txt
+          retention-days: 30

--- a/Development_Notes.md
+++ b/Development_Notes.md
@@ -1,0 +1,11 @@
+## Test tips
+
+Other than usual unit tests, we have some irregular tests:
+
+- **MemoryLeakTest**: This test checks for memory leaks in the code. As they are slow and its results are not deterministic, they are not run by default. To test them, run `mvn test -Pmemoryleak-tests`.
+- **load_test_all.sh**: This script runs a load test with different numbers of events, to check memory usage tendencies. It is not run by maven. You can run it manually with `./load_test_all.sh`. `load_test.sh` is a flexible version of that. See the comments in the script for more information.
+
+The above 2 tests are relatively important to detect memory leak issues. Make sure to run them from time to time, especially before releasing a new version.
+
+- **PerfTest**: This test contains various and relatively high load tests, which are run by default.
+- **SlownessTest**: This test verifies the behavior under the real slowness (but not very long). It is run by default.

--- a/Development_Notes.md
+++ b/Development_Notes.md
@@ -5,7 +5,7 @@ Other than usual unit tests, we have some irregular tests:
 - **MemoryLeakTest**: This test checks for memory leaks in the code. As they are slow and its results are not deterministic, they are not run by default. To test them, run `mvn test -Pmemoryleak-tests`.
 - **load_test_all.sh**: This script runs a load test with different numbers of events, to check memory usage tendencies. It is not run by maven. You can run it manually with `./load_test_all.sh`. `load_test.sh` is a flexible version of that. See the comments in the script for more information.
 
-The above 2 tests are relatively important to detect memory leak issues. Make sure to run them from time to time, especially before releasing a new version.
+The above 2 tests are relatively important to detect memory leak issues. Added to github action `pull-request.yml`.
 
 - **PerfTest**: This test contains various and relatively high load tests, which are run by default.
 - **SlownessTest**: This test verifies the behavior under the real slowness (but not very long). It is run by default.

--- a/drools-ansible-rulebook-integration-api/pom.xml
+++ b/drools-ansible-rulebook-integration-api/pom.xml
@@ -67,4 +67,48 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <!-- Default behavior in main build section -->
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/MemoryLeakTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Memory leak tests profile -->
+    <profile>
+      <id>memoryleak-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/MemoryLeakTest.java</include>
+              </includes>
+              <systemPropertyVariables>
+                <org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>WARN</org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/drools-ansible-rulebook-integration-api/pom.xml
+++ b/drools-ansible-rulebook-integration-api/pom.xml
@@ -66,49 +66,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <!-- Default behavior in main build section -->
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/MemoryLeakTest.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- Memory leak tests profile -->
-    <profile>
-      <id>memoryleak-tests</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <includes>
-                <include>**/MemoryLeakTest.java</include>
-              </includes>
-              <systemPropertyVariables>
-                <org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>WARN</org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/drools-ansible-rulebook-integration-api/src/test/resources/simplelogger.properties
+++ b/drools-ansible-rulebook-integration-api/src/test/resources/simplelogger.properties
@@ -2,7 +2,7 @@
 org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Logging detail level
-org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration=debug
+org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration=info
 
 # Set to true if you want the current date and time to be included in output messages.
 # Default is false, and will output the number of milliseconds elapsed since startup.

--- a/drools-ansible-rulebook-integration-main/load_test_all.sh
+++ b/drools-ansible-rulebook-integration-main/load_test_all.sh
@@ -37,3 +37,14 @@ for file in "${files[@]}"; do
 done
 
 echo "All runs complete. See result_all.txt for any STDERR output (testfile, usedMemory, timeTaken)."
+
+# Run MemoryLeakAnalyzer to check for memory leaks
+echo ""
+echo "Analyzing results for memory leaks..."
+java -cp "target/classes" org.drools.ansible.rulebook.integration.main.MemoryLeakAnalyzer result_all.txt
+
+# Capture the exit code
+ANALYZER_EXIT_CODE=$?
+
+# Exit with the same code as the analyzer
+exit $ANALYZER_EXIT_CODE

--- a/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/MemoryLeakAnalyzer.java
+++ b/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/MemoryLeakAnalyzer.java
@@ -61,6 +61,7 @@ public class MemoryLeakAnalyzer {
 
             if (hasMemoryLeak || parseResult.exceptionFound) {
                 System.err.println("\n❌ MEMORY LEAK DETECTED OR EXCEPTION FOUND!");
+                System.err.println("  Review the result file for details.\n");
                 System.exit(1);
             } else {
                 System.out.println("\n✅ No memory leak detected.");
@@ -107,7 +108,7 @@ public class MemoryLeakAnalyzer {
         }
 
         if (exceptionFound) {
-            System.err.println("\n⚠️  EXCEPTION FOUND IN RESULTS (potentially caused by a memory leak)");
+            System.err.println("\n⚠️  EXCEPTION FOUND IN RESULTS (potentially caused by a memory leak)\n");
         }
 
         if (results.isEmpty()) {

--- a/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/MemoryLeakAnalyzer.java
+++ b/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/MemoryLeakAnalyzer.java
@@ -1,0 +1,255 @@
+package org.drools.ansible.rulebook.integration.main;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Analyzes memory usage results from load tests to detect potential memory leaks.
+ * <p>
+ * This analyzer reads test results from a CSV file containing:
+ * - Test name (e.g., "24kb_1k_events.json")
+ * - Memory usage in bytes
+ * - Execution time in milliseconds
+ * <p>
+ * Analysis Logic:
+ * 1. Groups tests by type (matching vs non-matching events)
+ * 2. For each group, analyzes memory growth patterns across increasing event counts (1k → 10k → 100k → 1M)
+ * 3. Focuses on absolute memory increases rather than ratios to detect acceleration patterns
+ * <p>
+ * Memory Leak Detection Criteria:
+ * <p>
+ * 1. Absolute Increase Check:
+ * - Flags any single memory increase exceeding 50MB as suspicious
+ * <p>
+ * 2. Consecutive Acceleration Pattern:
+ * - Calculates the ratio between consecutive memory increases
+ * - If current increase is >3x the previous increase, it's marked as accelerating
+ * - Memory leak is detected only when 2+ consecutive accelerations occur
+ * - This prevents false positives from single spikes due to small previous increases
+ * <p>
+ * 3. Total Memory Growth:
+ * - Checks total memory increase from 1k to 1M events
+ * - Flags if total increase exceeds 150MB (3x the single-step threshold)
+ * <p>
+ * Exit Codes:
+ * - 0: No memory leak detected
+ * - 1: Memory leak detected based on the above criteria
+ * - 2: Error during analysis (file parsing, etc.)
+ * <p>
+ * Usage: java MemoryLeakAnalyzer <result_file>
+ */
+public class MemoryLeakAnalyzer {
+
+    private static final double INCREASE_GROWTH_THRESHOLD = 3.0; // Max 3x growth in memory increase between steps
+    private static final long ABSOLUTE_INCREASE_THRESHOLD = 50_000_000; // 50MB absolute increase warning
+
+    public static void main(String[] args) {
+        if (args.length != 1) {
+            System.err.println("Usage: java MemoryLeakAnalyzer <result_file>");
+            System.exit(1);
+        }
+
+        String resultFile = args[0];
+        MemoryLeakAnalyzer analyzer = new MemoryLeakAnalyzer();
+
+        try {
+            List<TestResult> results = analyzer.parseResultFile(resultFile);
+            boolean hasMemoryLeak = analyzer.analyzeResults(results);
+
+            if (hasMemoryLeak) {
+                System.err.println("\n❌ MEMORY LEAK DETECTED!");
+                System.exit(1);
+            } else {
+                System.out.println("\n✅ No memory leak detected.");
+                System.exit(0);
+            }
+        } catch (Exception e) {
+            System.err.println("Error analyzing results: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(2);
+        }
+    }
+
+    private List<TestResult> parseResultFile(String filename) throws IOException {
+        List<TestResult> results = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                String[] parts = line.split(",");
+                if (parts.length != 3) {
+                    System.err.println("Skipping invalid line: " + line);
+                    continue;
+                }
+
+                String testName = parts[0].trim();
+                long memoryUsage = Long.parseLong(parts[1].trim());
+                long duration = Long.parseLong(parts[2].trim());
+
+                results.add(new TestResult(testName, memoryUsage, duration));
+            }
+        }
+
+        return results;
+    }
+
+    private boolean analyzeResults(List<TestResult> results) {
+        boolean hasLeak = false;
+
+        System.out.println("Memory Leak Analysis Report");
+        System.out.println("===========================\n");
+
+        // Group results by test type (matching vs unmatching)
+        List<TestResult> matchingTests = new ArrayList<>();
+        List<TestResult> unmatchingTests = new ArrayList<>();
+
+        for (TestResult result : results) {
+            if (result.testName.contains("unmatch")) {
+                unmatchingTests.add(result);
+            } else {
+                matchingTests.add(result);
+            }
+        }
+
+        System.out.println("Matching Events Tests:");
+        hasLeak |= analyzeTestGroup(matchingTests);
+
+        System.out.println("\nNon-Matching Events Tests:");
+        hasLeak |= analyzeTestGroup(unmatchingTests);
+
+        return hasLeak;
+    }
+
+    private boolean analyzeTestGroup(List<TestResult> tests) {
+        if (tests.isEmpty()) {
+            return false;
+        }
+
+        boolean hasLeak = false;
+
+        // Sort by event count (1k, 10k, 100k, 1m)
+        tests.sort((a, b) -> {
+            int eventCountA = extractEventCount(a.testName);
+            int eventCountB = extractEventCount(b.testName);
+            return Integer.compare(eventCountA, eventCountB);
+        });
+
+        // Print test results
+        System.out.println("Test Name                          Memory (bytes)    Duration (ms)");
+        System.out.println("-----------------------------------------------------------------");
+        for (TestResult test : tests) {
+            System.out.printf("%-34s %,13d    %,12d%n",
+                              test.testName, test.memoryUsage, test.duration);
+        }
+
+        // Analyze absolute memory increases between consecutive test sizes
+        System.out.println("\nMemory Increase Analysis:");
+        Long previousIncrease = null;
+        int consecutiveIncreases = 0;
+
+        for (int i = 1; i < tests.size(); i++) {
+            TestResult prev = tests.get(i - 1);
+            TestResult curr = tests.get(i);
+
+            long currentIncrease = curr.memoryUsage - prev.memoryUsage;
+            int prevEvents = extractEventCount(prev.testName);
+            int currEvents = extractEventCount(curr.testName);
+
+            System.out.printf("  %s → %s:%n",
+                              formatEventCount(prevEvents), formatEventCount(currEvents));
+            System.out.printf("    Memory increase: %,d bytes", currentIncrease);
+
+            // Check if increase is abnormally high
+            if (Math.abs(currentIncrease) > ABSOLUTE_INCREASE_THRESHOLD) {
+                System.out.printf(" ⚠️  LARGE INCREASE!%n");
+                hasLeak = true;
+            } else if (previousIncrease != null && currentIncrease > 0 && previousIncrease > 0) {
+                // Compare with previous increase
+                double increaseRatio = (double) currentIncrease / previousIncrease;
+                System.out.printf(" (%.2fx previous increase)", increaseRatio);
+
+                if (increaseRatio > INCREASE_GROWTH_THRESHOLD) {
+                    consecutiveIncreases++;
+                    if (consecutiveIncreases >= 2) {
+                        System.out.printf(" ⚠️  CONSECUTIVE ACCELERATING GROWTH!%n");
+                        hasLeak = true;
+                    } else {
+                        System.out.printf(" ⚠ (noted, but not a leak if it's not consecutive)%n");
+                    }
+                } else {
+                    consecutiveIncreases = 0; // Reset counter
+                    System.out.printf(" ✓%n");
+                }
+            } else {
+                consecutiveIncreases = 0; // Reset counter
+                System.out.printf(" ✓%n");
+            }
+
+            previousIncrease = currentIncrease;
+        }
+
+        // Check total memory increase
+        if (tests.size() >= 2) {
+            TestResult first = tests.get(0);
+            TestResult last = tests.get(tests.size() - 1);
+            long totalIncrease = last.memoryUsage - first.memoryUsage;
+
+            System.out.printf("\nTotal memory increase (1k → 1M): %,d bytes", totalIncrease);
+            if (totalIncrease > ABSOLUTE_INCREASE_THRESHOLD * 3) {
+                System.out.printf(" ⚠️  EXCESSIVE TOTAL INCREASE!%n");
+                hasLeak = true;
+            } else {
+                System.out.printf(" ✓%n");
+            }
+        }
+
+        return hasLeak;
+    }
+
+    private int extractEventCount(String testName) {
+        if (testName.contains("1m_")) {
+            return 1000000;
+        }
+        if (testName.contains("100k_")) {
+            return 100000;
+        }
+        if (testName.contains("10k_")) {
+            return 10000;
+        }
+        if (testName.contains("1k_")) {
+            return 1000;
+        }
+        return 0;
+    }
+
+    private String formatEventCount(int count) {
+        if (count >= 1000000) {
+            return (count / 1000000) + "M";
+        }
+        if (count >= 1000) {
+            return (count / 1000) + "k";
+        }
+        return String.valueOf(count);
+    }
+
+    private static class TestResult {
+
+        final String testName;
+        final long memoryUsage;
+        final long duration;
+
+        TestResult(String testName, long memoryUsage, long duration) {
+            this.testName = testName;
+            this.memoryUsage = memoryUsage;
+            this.duration = duration;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -254,5 +254,47 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Default profile - exclude memory leak tests -->
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/MemoryLeakTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Memory leak tests profile -->
+    <profile>
+      <id>memoryleak-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/MemoryLeakTest.java</include>
+              </includes>
+              <systemPropertyVariables>
+                <org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>WARN</org.slf4j.simpleLogger.log.org.drools.ansible.rulebook.integration>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
- `MemoryLeakTest` doesn't run by default.  It runs only with `-Pmemoryleak-tests`
- Added a job to run `MemoryLeakTest` and `load_test_all.sh` in GHA PR check
    - Usually we want to avoid such load tests in a regular CI, but a memory issue is crucial to this project, so it's better to detect earlier. (Actually, these tests are not very slow, just a few minutes)
- Added `MemoryLeakAnalyzer` to check if there is any sign of memory leak in `load_test_all.sh` result. It helps the GHA