### PR TITLE
use 999-SNAPSHOT instead of 2.0.0-SNAPSHOT

### DIFF
--- a/drools-ansible-rulebook-integration-api/pom.xml
+++ b/drools-ansible-rulebook-integration-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-benchmark/pom.xml
+++ b/drools-ansible-rulebook-integration-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-benchmark</artifactId>

--- a/drools-ansible-rulebook-integration-core-rest/pom.xml
+++ b/drools-ansible-rulebook-integration-core-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-core-rest</artifactId>

--- a/drools-ansible-rulebook-integration-main/pom.xml
+++ b/drools-ansible-rulebook-integration-main/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-protoextractor/pom.xml
+++ b/drools-ansible-rulebook-integration-protoextractor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-runtime/pom.xml
+++ b/drools-ansible-rulebook-integration-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-runtime</artifactId>

--- a/drools-ansible-rulebook-integration-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-visualization/pom.xml
+++ b/drools-ansible-rulebook-integration-visualization/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   
   <groupId>org.drools</groupId>
   <artifactId>drools-ansible-rulebook-integration</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
For now, the main branch is purely the latest development branch, which should not be consumed by drools_jpy. But `2.0.0-SNAPSHOT` is a little confusing, so drools_jpy had mistakenly picked it before.

Changing the version name to the explicitly development-like `999-SNAPSHOT`. Also it would align with the drools main version policy.