### PR TITLE
Clean up project dependencies mapping in YAML file

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -1,18 +1,7 @@
 version: "2.1"
 dependencies:
   - project: kiegroup/drools
-    mapping:
-      dependant:
-        default:
-          # whenever drools branch changes, please update .ci/jenkins/Jenkinsfile.prod.nightly as well if needed
-          - source: 9.103.x-prod
-            target: 1.0.x
-
+    
   - project: kiegroup/drools-ansible-rulebook-integration
     dependencies:
       - project: kiegroup/drools
-    mapping:
-      dependencies:
-        default:
-          - source: 1.0.x
-            target: 9.103.x-prod

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.11']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Ansible Integration / ${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }}
@@ -58,7 +58,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/maven@main
         with:
           java-version: '17'
-          maven-version: '3.9.3'
+          maven-version: '3.9.11'
 
       - name: Build Chain
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main


### PR DESCRIPTION
Removed outdated mapping for drools project dependencies.

Main branch should depend on main branches only drools -> drools-ansible-rulebook-integration

mapping is important for 1.0.x/2.0.x or any new branch ONLY