### PR TITLE
Reapply "Externalize retained EventRecords into row storage (#177)" (…

### DIFF
--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HARulesEvaluator.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HARulesEvaluator.java
@@ -134,7 +134,7 @@ public class HARulesEvaluator extends SyncRulesEvaluator {
     @Override
     protected void processDiscardedFact(InternalFactHandle fh) {
         getEventUuid(fh).ifPresentOrElse(
-                uuid -> getHaSessionContext().removeTrackedRecord(uuid),
-                () -> getHaSessionContext().removeTrackedRecordByFactHandle(fh.getId()));
+                uuid -> getHaSessionContext().discardTrackedRecord(uuid),
+                () -> getHaSessionContext().discardTrackedRecordByFactHandle(fh.getId()));
     }
 }

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HASessionContext.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HASessionContext.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +25,15 @@ public class HASessionContext {
 
     // Associate factHandleIds to identifiers for efficient lookup during updates/deletions
     private final Map<Long, String> factHandleIndex = new HashMap<>();
+
+    // Stable per-record sequence for deterministic row-backed recovery ordering
+    private final Map<String, Long> recordSequenceIndex = new HashMap<>();
+
+    private final Map<String, String> eventRecordShaIndex = new HashMap<>();
+
+    private final List<EventRecordChange> pendingEventRecordChanges = new ArrayList<>();
+
+    private long nextRecordSequence = 0L;
 
     // Circular buffer of processed event IDs for duplicate detection
     private final LinkedHashSet<String> processedEventIds = new LinkedHashSet<>();
@@ -43,7 +54,13 @@ public class HASessionContext {
             return;
         }
 
+        removeFactHandleIndexForIdentifier(identifier);
         trackedRecords.put(identifier, eventRecord);
+        long recordSequence = recordSequenceIndex.computeIfAbsent(identifier, ignored -> nextRecordSequence++);
+        EventRecordEntry entry = new EventRecordEntry(identifier, recordSequence, eventRecord);
+        String eventRecordSHA = HAUtils.calculateEventRecordSHA(entry);
+        eventRecordShaIndex.put(identifier, eventRecordSHA);
+        pendingEventRecordChanges.add(EventRecordChange.upsert(new EventRecordEntry(identifier, recordSequence, eventRecord, eventRecordSHA)));
         if (factHandleId != null) {
             factHandleIndex.put(factHandleId, identifier);
         }
@@ -53,13 +70,45 @@ public class HASessionContext {
         if (identifier == null) {
             return;
         }
-        trackedRecords.remove(identifier);
+        if (trackedRecords.remove(identifier) != null) {
+            removeFactHandleIndexForIdentifier(identifier);
+            recordSequenceIndex.remove(identifier);
+            eventRecordShaIndex.remove(identifier);
+            pendingEventRecordChanges.add(EventRecordChange.delete(identifier));
+        }
+    }
+
+    /**
+     * Discards a record that was inserted and then immediately dropped during the same
+     * evaluation cycle before it ever became retained HA state.
+     *
+     * This is used for unmatched/disconnected facts/events. In that case we must not
+     * persist an UPSERT followed by a DELETE because some backends, notably H2 with
+     * large CLOB payloads, still materialize the transient row contents in memory.
+     */
+    public void discardTrackedRecord(String identifier) {
+        if (identifier == null) {
+            return;
+        }
+        if (trackedRecords.remove(identifier) != null) {
+            removeFactHandleIndexForIdentifier(identifier);
+            recordSequenceIndex.remove(identifier);
+            eventRecordShaIndex.remove(identifier);
+            pendingEventRecordChanges.removeIf(change -> identifier.equals(change.getRecordIdentifier()));
+        }
     }
 
     public void removeTrackedRecordByFactHandle(long factHandleId) {
         String identifier = factHandleIndex.remove(factHandleId);
         if (identifier != null) {
-            trackedRecords.remove(identifier);
+            removeTrackedRecord(identifier);
+        }
+    }
+
+    public void discardTrackedRecordByFactHandle(long factHandleId) {
+        String identifier = factHandleIndex.remove(factHandleId);
+        if (identifier != null) {
+            discardTrackedRecord(identifier);
         }
     }
 
@@ -76,6 +125,11 @@ public class HASessionContext {
             EventRecord eventRecord = trackedRecords.get(identifier);
             if (eventRecord != null) {
                 eventRecord.setEventJson(updatedJson);
+                long recordSequence = recordSequenceIndex.computeIfAbsent(identifier, ignored -> nextRecordSequence++);
+                EventRecordEntry entry = new EventRecordEntry(identifier, recordSequence, eventRecord);
+                String eventRecordSHA = HAUtils.calculateEventRecordSHA(entry);
+                eventRecordShaIndex.put(identifier, eventRecordSHA);
+                pendingEventRecordChanges.add(EventRecordChange.upsert(new EventRecordEntry(identifier, recordSequence, eventRecord, eventRecordSHA)));
                 logger.debug("Updated EventRecord for identifier: {}, factHandleId: {}", identifier, factHandleId);
             } else {
                 logger.warn("No EventRecord found for identifier: {} during update", identifier);
@@ -125,6 +179,28 @@ public class HASessionContext {
         if (ids != null) {
             processedEventIds.addAll(ids);
         }
+    }
+
+    public List<EventRecordChange> drainEventRecordChanges() {
+        List<EventRecordChange> changes = new ArrayList<>(pendingEventRecordChanges);
+        pendingEventRecordChanges.clear();
+        return changes;
+    }
+
+    public List<EventRecordEntry> snapshotEventRecordEntries() {
+        List<EventRecordEntry> entries = new ArrayList<>(trackedRecords.size());
+        for (Map.Entry<String, EventRecord> entry : trackedRecords.entrySet()) {
+            String identifier = entry.getKey();
+            long recordSequence = recordSequenceIndex.computeIfAbsent(identifier, ignored -> nextRecordSequence++);
+            String eventRecordSHA = eventRecordShaIndex.computeIfAbsent(identifier,
+                    ignored -> HAUtils.calculateEventRecordSHA(new EventRecordEntry(identifier, recordSequence, entry.getValue())));
+            entries.add(new EventRecordEntry(identifier, recordSequence, entry.getValue(), eventRecordSHA));
+        }
+        return entries;
+    }
+
+    private void removeFactHandleIndexForIdentifier(String identifier) {
+        factHandleIndex.entrySet().removeIf(entry -> identifier.equals(entry.getValue()));
     }
 
     public static final class PendingRecord {

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HAStateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HAStateManager.java
@@ -7,6 +7,8 @@ import org.drools.ansible.rulebook.integration.api.RulesExecutor;
 import org.drools.ansible.rulebook.integration.api.domain.RulesSet;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.drools.ansible.rulebook.integration.ha.model.HAStats;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.drools.ansible.rulebook.integration.ha.model.MatchingEvent;
 
 /**
@@ -79,6 +81,22 @@ public interface HAStateManager {
      * @param sessionState The session state to persist
      */
     void persistSessionState(SessionState sessionState);
+
+    /**
+     * Persist row-level retained EventRecord changes for a ruleset.
+     *
+     * @param ruleSetName The ruleset name
+     * @param eventRecordChanges Row-level upsert/delete changes
+     */
+    void persistEventRecordChanges(String ruleSetName, List<EventRecordChange> eventRecordChanges);
+
+    /**
+     * Load retained EventRecord rows for a ruleset in recovery order.
+     *
+     * @param ruleSetName The ruleset name
+     * @return ordered retained EventRecord entries
+     */
+    List<EventRecordEntry> getPersistedEventRecords(String ruleSetName);
 
     /**
      * Recover drools session using session state from the database
@@ -197,6 +215,24 @@ public interface HAStateManager {
     void persistSessionStateStatsAndMatchingEvents(SessionState sessionState, List<MatchingEvent> matchingEvents);
 
     /**
+     * Persist session state, HA stats, row-level retained EventRecord changes,
+     * and matching events in a single transaction.
+     */
+    void persistSessionStateStatsEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                               List<EventRecordChange> eventRecordChanges,
+                                                               List<MatchingEvent> matchingEvents);
+
+    /**
+     * Persist session state, HA stats, a full retained EventRecord row snapshot,
+     * and matching events in a single transaction.
+     * Intended for recovery/startup flows where the retained set may shrink
+     * without explicit delete deltas.
+     */
+    void persistSessionStateStatsEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                     List<EventRecordEntry> eventRecordEntries,
+                                                                     List<MatchingEvent> matchingEvents);
+
+    /**
      * Delete the persisted SessionState record for a given ruleset.
      *
      * @param ruleSetName The name of the ruleset
@@ -213,6 +249,24 @@ public interface HAStateManager {
     void persistSessionStateAndMatchingEvents(SessionState sessionState, List<MatchingEvent> matchingEvents);
 
     /**
+     * Persist session state, row-level retained EventRecord changes, and matching
+     * events in a single transaction. Used after recovery.
+     */
+    void persistSessionStateEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                          List<EventRecordChange> eventRecordChanges,
+                                                          List<MatchingEvent> matchingEvents);
+
+    /**
+     * Persist session state, a full retained EventRecord row snapshot, and
+     * matching events in a single transaction.
+     * Intended for recovery/startup flows where the retained set may shrink
+     * without explicit delete deltas.
+     */
+    void persistSessionStateEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                List<EventRecordEntry> eventRecordEntries,
+                                                                List<MatchingEvent> matchingEvents);
+
+    /**
      * Persist all leader startup DB writes in a single transaction.
      * Called once at the end of enableLeader() after all in-memory recovery is complete.
      * <p>
@@ -227,6 +281,7 @@ public interface HAStateManager {
      * @param matchingEvents         recovery matching events to insert
      */
     void persistLeaderStartup(List<SessionState> sessionStatesToPersist,
+                              Map<String, List<EventRecordEntry>> eventRecordEntriesByRuleSet,
                               List<String> rulesetNamesToDelete,
                               List<MatchingEvent> matchingEvents);
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HATableNames.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HATableNames.java
@@ -8,9 +8,11 @@ public final class HATableNames {
 
     public static final String SESSION_STATE = "drools_ansible_session_state";
     public static final String MATCHING_EVENT = "drools_ansible_matching_event";
+    public static final String EVENT_RECORD = "drools_ansible_event_record";
     public static final String ACTION_INFO = "drools_ansible_action_info";
     public static final String HA_STATS = "drools_ansible_ha_stats";
     public static final String IDX_MATCHING_EVENT_HA_UUID = "idx_da_matching_event_ha_uuid";
+    public static final String IDX_EVENT_RECORD_ORDER = "idx_da_event_record_order";
     public static final String IDX_ACTION_INFO_ME = "idx_da_action_info_me";
 
     private HATableNames() {

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HAUtils.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/HAUtils.java
@@ -5,10 +5,16 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Comparator;
 
 import org.drools.ansible.rulebook.integration.api.rulesmodel.RulesModelUtil;
+import org.drools.ansible.rulebook.integration.api.io.JsonMapper;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.drools.model.prototype.impl.HashMapEventImpl;
 import org.kie.api.prototype.PrototypeFactInstance;
@@ -74,6 +80,45 @@ public class HAUtils {
 
         String hashableContent = sessionState.toHashableContent();
         return sha256(hashableContent);
+    }
+
+    public static String calculateEventRecordSHA(EventRecordEntry entry) {
+        if (entry == null || entry.getRecord() == null) {
+            return null;
+        }
+        return sha256(toEventRecordHashableContent(entry));
+    }
+
+    public static String calculateEventRecordsManifestSHA(List<EventRecordEntry> entries) {
+        if (entries == null) {
+            return sha256("[]");
+        }
+        List<Map<String, Object>> manifest = entries.stream()
+                .sorted(Comparator.comparingLong(EventRecordEntry::getRecordSequence)
+                                   .thenComparing(EventRecordEntry::getRecordIdentifier))
+                .map(entry -> {
+                    Map<String, Object> contentMap = new LinkedHashMap<>();
+                    contentMap.put("recordIdentifier", entry.getRecordIdentifier());
+                    contentMap.put("recordSequence", entry.getRecordSequence());
+                    contentMap.put("eventRecordSHA", entry.getEventRecordSHA() != null
+                            ? entry.getEventRecordSHA()
+                            : calculateEventRecordSHA(entry));
+                    return contentMap;
+                })
+                .toList();
+        return sha256(JsonMapper.toJson(manifest));
+    }
+
+    private static String toEventRecordHashableContent(EventRecordEntry entry) {
+        EventRecord record = entry.getRecord();
+        Map<String, Object> contentMap = new LinkedHashMap<>();
+        contentMap.put("recordIdentifier", entry.getRecordIdentifier());
+        contentMap.put("recordSequence", entry.getRecordSequence());
+        contentMap.put("insertedAt", record.getInsertedAt());
+        contentMap.put("recordType", record.getRecordType());
+        contentMap.put("eventJson", record.getEventJson());
+        contentMap.put("expirationDuration", record.getExpirationDuration());
+        return JsonMapper.toJson(contentMap);
     }
 
     /**

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/EventRecordChange.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/EventRecordChange.java
@@ -1,0 +1,44 @@
+package org.drools.ansible.rulebook.integration.ha.model;
+
+import java.util.Objects;
+
+public class EventRecordChange {
+
+    public enum Type {
+        UPSERT,
+        DELETE
+    }
+
+    private final Type type;
+
+    private final String recordIdentifier;
+
+    private final EventRecordEntry entry;
+
+    private EventRecordChange(Type type, String recordIdentifier, EventRecordEntry entry) {
+        this.type = Objects.requireNonNull(type, "type must not be null");
+        this.recordIdentifier = Objects.requireNonNull(recordIdentifier, "recordIdentifier must not be null");
+        this.entry = entry;
+    }
+
+    public static EventRecordChange upsert(EventRecordEntry entry) {
+        Objects.requireNonNull(entry, "entry must not be null");
+        return new EventRecordChange(Type.UPSERT, entry.getRecordIdentifier(), entry);
+    }
+
+    public static EventRecordChange delete(String recordIdentifier) {
+        return new EventRecordChange(Type.DELETE, recordIdentifier, null);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getRecordIdentifier() {
+        return recordIdentifier;
+    }
+
+    public EventRecordEntry getEntry() {
+        return entry;
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/EventRecordEntry.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/EventRecordEntry.java
@@ -1,0 +1,41 @@
+package org.drools.ansible.rulebook.integration.ha.model;
+
+import java.util.Objects;
+
+public class EventRecordEntry {
+
+    private final String recordIdentifier;
+
+    private final long recordSequence;
+
+    private final EventRecord record;
+
+    private final String eventRecordSHA;
+
+    public EventRecordEntry(String recordIdentifier, long recordSequence, EventRecord record) {
+        this(recordIdentifier, recordSequence, record, null);
+    }
+
+    public EventRecordEntry(String recordIdentifier, long recordSequence, EventRecord record, String eventRecordSHA) {
+        this.recordIdentifier = Objects.requireNonNull(recordIdentifier, "recordIdentifier must not be null");
+        this.recordSequence = recordSequence;
+        this.record = record;
+        this.eventRecordSHA = eventRecordSHA;
+    }
+
+    public String getRecordIdentifier() {
+        return recordIdentifier;
+    }
+
+    public long getRecordSequence() {
+        return recordSequence;
+    }
+
+    public EventRecord getRecord() {
+        return record;
+    }
+
+    public String getEventRecordSHA() {
+        return eventRecordSHA;
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/SessionState.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/model/SessionState.java
@@ -30,6 +30,13 @@ public class SessionState {
     // For integrity checks
     private String currentStateSHA;      // SHA256 of current state
 
+    /*
+     * Transient row-backed retained-event manifest. This is not stored as a
+     * separate DB column; it is folded into currentStateSHA when retained
+     * EventRecords are persisted in drools_ansible_event_record rows.
+     */
+    private String eventRecordsManifestSHA;
+
     // Extensibility columns for future use without schema migration
     private Map<String, Object> metadata = new HashMap<>();
     private Map<String, Object> properties = new HashMap<>();
@@ -112,6 +119,13 @@ public class SessionState {
         this.currentStateSHA = currentStateSHA;
     }
 
+    public String getEventRecordsManifestSHA() {
+        return eventRecordsManifestSHA;
+    }
+
+    public void setEventRecordsManifestSHA(String eventRecordsManifestSHA) {
+        this.eventRecordsManifestSHA = eventRecordsManifestSHA;
+    }
 
     public Map<String, Object> getMetadata() {
         return metadata;
@@ -160,10 +174,15 @@ public class SessionState {
         contentMap.put("haUuid", haUuid);
         contentMap.put("ruleSetName", ruleSetName);
         contentMap.put("rulebookHash", rulebookHash);
-        // Keep partialEvents as typed EventRecord objects. Do not parse eventJson into
-        // Map<String, Object> or re-serialize it here; JSON numeric type drift or map
-        // ordering changes could otherwise create false SHA mismatches after recovery.
-        contentMap.put("partialEvents", partialEvents);
+        if (eventRecordsManifestSHA != null) {
+            contentMap.put("eventRecordsManifestSHA", eventRecordsManifestSHA);
+        } else {
+            // Legacy blob-backed state keeps partialEvents as typed EventRecord objects.
+            // Do not parse eventJson into Map<String, Object> or re-serialize it here;
+            // JSON numeric type drift or map ordering changes could otherwise create
+            // false SHA mismatches after recovery.
+            contentMap.put("partialEvents", partialEvents);
+        }
         contentMap.put("processedEventIds", processedEventIds);
         contentMap.put("createdTime", createdTime);
         contentMap.put("persistedTime", persistedTime);

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/src/main/java/org/drools/ansible/rulebook/integration/ha/h2/H2Schema.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/src/main/java/org/drools/ansible/rulebook/integration/ha/h2/H2Schema.java
@@ -1,8 +1,10 @@
 package org.drools.ansible.rulebook.integration.ha.h2;
 
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.ACTION_INFO;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.EVENT_RECORD;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.HA_STATS;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_ACTION_INFO_ME;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_EVENT_RECORD_ORDER;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_MATCHING_EVENT_HA_UUID;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.MATCHING_EVENT;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.SESSION_STATE;
@@ -51,6 +53,30 @@ public class H2Schema {
                         + "CONSTRAINT uq_session_state_ha_ruleset UNIQUE(ha_uuid, rule_set_name)"
                         + ")";
                 stmt.execute(createSessionStateTable);
+
+                String createEventRecordTable =
+                        "CREATE TABLE IF NOT EXISTS " + EVENT_RECORD + " ("
+                        + "ha_uuid VARCHAR(255) NOT NULL, "
+                        + "rule_set_name VARCHAR(255) NOT NULL, "
+                        + "record_identifier VARCHAR(255) NOT NULL, "
+                        + "inserted_at BIGINT NOT NULL, "
+                        + "record_sequence BIGINT NOT NULL, "
+                        + "record_type VARCHAR(64) NOT NULL, "
+                        + "event_json CLOB, "
+                        + "expiration_duration BIGINT, "
+                        + "event_record_sha VARCHAR(64) NOT NULL, "
+                        + "metadata CLOB DEFAULT '{}', "
+                        + "properties CLOB DEFAULT '{}', "
+                        + "settings CLOB DEFAULT '{}', "
+                        + "ext CLOB DEFAULT '{}', "
+                        + "PRIMARY KEY (ha_uuid, rule_set_name, record_identifier)"
+                        + ")";
+                stmt.execute(createEventRecordTable);
+
+                String createEventRecordOrderIndex =
+                        "CREATE INDEX IF NOT EXISTS " + IDX_EVENT_RECORD_ORDER
+                        + " ON " + EVENT_RECORD + "(ha_uuid, rule_set_name, inserted_at, record_sequence, record_identifier)";
+                stmt.execute(createEventRecordOrderIndex);
 
                 // Create MatchingEvent table
                 String createMatchingEventTable =
@@ -149,6 +175,25 @@ public class H2Schema {
                     }
                 }
 
+                stmt.execute("CREATE TABLE IF NOT EXISTS " + EVENT_RECORD + " ("
+                        + "ha_uuid VARCHAR(255) NOT NULL, "
+                        + "rule_set_name VARCHAR(255) NOT NULL, "
+                        + "record_identifier VARCHAR(255) NOT NULL, "
+                        + "inserted_at BIGINT NOT NULL, "
+                        + "record_sequence BIGINT NOT NULL, "
+                        + "record_type VARCHAR(64) NOT NULL, "
+                        + "event_json CLOB, "
+                        + "expiration_duration BIGINT, "
+                        + "event_record_sha VARCHAR(64) NOT NULL, "
+                        + "metadata CLOB DEFAULT '{}', "
+                        + "properties CLOB DEFAULT '{}', "
+                        + "settings CLOB DEFAULT '{}', "
+                        + "ext CLOB DEFAULT '{}', "
+                        + "PRIMARY KEY (ha_uuid, rule_set_name, record_identifier)"
+                        + ")");
+                stmt.execute("CREATE INDEX IF NOT EXISTS " + IDX_EVENT_RECORD_ORDER
+                        + " ON " + EVENT_RECORD + "(ha_uuid, rule_set_name, inserted_at, record_sequence, record_identifier)");
+
                 // Migration: drop version column and update UNIQUE constraint
                 // Step 1: Drop old UNIQUE constraints (auto-generated name unknown in H2)
                 try {
@@ -198,6 +243,7 @@ public class H2Schema {
                 // Drop in reverse order due to foreign keys
                 stmt.execute("DROP TABLE IF EXISTS " + ACTION_INFO);
                 stmt.execute("DROP TABLE IF EXISTS " + MATCHING_EVENT);
+                stmt.execute("DROP TABLE IF EXISTS " + EVENT_RECORD);
                 stmt.execute("DROP TABLE IF EXISTS " + SESSION_STATE);
                 stmt.execute("DROP TABLE IF EXISTS " + HA_STATS);
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/src/main/java/org/drools/ansible/rulebook/integration/ha/h2/H2StateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/src/main/java/org/drools/ansible/rulebook/integration/ha/h2/H2StateManager.java
@@ -19,10 +19,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.drools.ansible.rulebook.integration.ha.api.AbstractHAStateManager;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.drools.ansible.rulebook.integration.ha.model.HAStats;
 import org.drools.ansible.rulebook.integration.ha.model.MatchingEvent;
 import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +33,11 @@ import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValu
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValue;
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.toJson;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.ACTION_INFO;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.EVENT_RECORD;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.HA_STATS;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.MATCHING_EVENT;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.SESSION_STATE;
+import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.calculateEventRecordSHA;
 
 /**
  * H2 implementation of HAStateManager with simplified domain model
@@ -219,13 +224,26 @@ public class H2StateManager extends AbstractHAStateManager {
                 sessionState.setRuleSetName(rs.getString("rule_set_name"));
                 sessionState.setRulebookHash(rs.getString("rulebook_hash"));
 
-                String partialEventsJson = decryptIfEnabled(rs.getString("partial_matching_events"));
-                if (partialEventsJson != null) {
-                    try {
-                        List<EventRecord> partialEvents = OBJECT_MAPPER.readValue(partialEventsJson, EVENT_RECORD_LIST_TYPE);
-                        sessionState.setPartialEvents(partialEvents);
-                    } catch (Exception e) {
-                        logger.error("Failed to deserialize partial events", e);
+                List<EventRecordEntry> eventRecordEntries = getPersistedEventRecords(ruleSetName);
+                if (!eventRecordEntries.isEmpty()) {
+                    sessionState.setPartialEvents(eventRecordEntries.stream()
+                                                          .map(EventRecordEntry::getRecord)
+                                                          .toList());
+                    sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(eventRecordEntries));
+                } else {
+                    String encryptedPartialEvents = rs.getString("partial_matching_events");
+                    if (encryptedPartialEvents != null) {
+                        String partialEventsJson = decryptIfEnabled(encryptedPartialEvents);
+                        try {
+                            List<EventRecord> partialEvents = OBJECT_MAPPER.readValue(partialEventsJson, EVENT_RECORD_LIST_TYPE);
+                            sessionState.setPartialEvents(partialEvents);
+                        } catch (Exception e) {
+                            logger.error("Failed to deserialize partial events", e);
+                        }
+                        sessionState.setEventRecordsManifestSHA(null);
+                    } else {
+                        sessionState.setPartialEvents(new ArrayList<>());
+                        sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(List.of()));
                     }
                 }
 
@@ -281,6 +299,57 @@ public class H2StateManager extends AbstractHAStateManager {
     }
 
     @Override
+    public void persistEventRecordChanges(String ruleSetName, List<EventRecordChange> eventRecordChanges) {
+        if (!isLeader) {
+            throw new IllegalStateException("Cannot persist EventRecord changes - not leader");
+        }
+        if (eventRecordChanges == null || eventRecordChanges.isEmpty()) {
+            return;
+        }
+
+        List<PreparedEventRecordChange> preparedChanges = prepareEventRecordChanges(eventRecordChanges);
+
+        executeInTransaction("Failed to persist EventRecord changes", conn -> {
+            applyEventRecordChanges(conn, ruleSetName, preparedChanges);
+        });
+    }
+
+    @Override
+    public List<EventRecordEntry> getPersistedEventRecords(String ruleSetName) {
+        String sql = "SELECT record_identifier, inserted_at, record_sequence, record_type, event_json, expiration_duration, event_record_sha"
+                + " FROM " + EVENT_RECORD
+                + " WHERE ha_uuid = ? AND rule_set_name = ?"
+                + " ORDER BY record_sequence, record_identifier";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+
+            List<EventRecordEntry> entries = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    EventRecordEntry entry = readEventRecordEntry(rs);
+                    String persistedSha = rs.getString("event_record_sha");
+                    String calculatedSha = calculateEventRecordSHA(entry);
+                    if (!persistedSha.equals(calculatedSha)) {
+                        throw new IllegalStateException("EventRecord SHA mismatch for ruleSetName=" + ruleSetName
+                                                                + ", recordIdentifier=" + entry.getRecordIdentifier());
+                    }
+                    entries.add(entry);
+                }
+            }
+            return entries;
+        } catch (SQLException e) {
+            logger.error("Failed to get EventRecord rows", e);
+            throw new RuntimeException("Failed to get EventRecord rows", e);
+        }
+    }
+
+    private record PreparedEventRecordChange(EventRecordChange change, String encryptedEventJson, String eventRecordSha) {
+    }
+
+    @Override
     public void persistSessionStateAndStats(SessionState sessionState) {
         validateForPersist(sessionState);
 
@@ -318,10 +387,7 @@ public class H2StateManager extends AbstractHAStateManager {
         prepareHAStatsForPersist();
 
         // Pre-compute encrypted data outside the transaction to minimize lock duration
-        String encryptedPartialEvents = null;
-        if (sessionState.getPartialEvents() != null) {
-            encryptedPartialEvents = encryptIfEnabled(toJson(sessionState.getPartialEvents()));
-        }
+        String encryptedPartialEvents = prepareSessionPartialEventsForPersist(sessionState);
 
         List<String> encryptedEventDataList = new ArrayList<>();
         if (!matchingEvents.isEmpty()) {
@@ -345,6 +411,83 @@ public class H2StateManager extends AbstractHAStateManager {
                      matchingEvents.size(), haUuid);
     }
 
+    @Override
+    public void persistSessionStateStatsEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                                      List<EventRecordChange> eventRecordChanges,
+                                                                      List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+
+        if (haStats == null) {
+            persistSessionStateEventRecordsAndMatchingEvents(sessionState, eventRecordChanges, matchingEvents);
+            return;
+        }
+
+        ensureVersionInMetadata(sessionState.getMetadata());
+        prepareHAStatsForPersist();
+
+        List<PreparedEventRecordChange> preparedEventRecordChanges = prepareEventRecordChanges(eventRecordChanges);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null && !matchingEvents.isEmpty()) {
+            for (MatchingEvent me : matchingEvents) {
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, HAStats, EventRecord changes, and matching events", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            doHAStatsUpsert(conn);
+            applyEventRecordChanges(conn, sessionState.getRuleSetName(), preparedEventRecordChanges);
+
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+
+        logger.debug("Persisted SessionState, HAStats, {} EventRecord changes, and {} matching events in single transaction for haUuid: {}",
+                     eventRecordChanges != null ? eventRecordChanges.size() : 0,
+                     matchingEvents != null ? matchingEvents.size() : 0,
+                     haUuid);
+    }
+
+    @Override
+    public void persistSessionStateStatsEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                            List<EventRecordEntry> eventRecordEntries,
+                                                                            List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+
+        if (haStats == null) {
+            persistSessionStateEventRecordEntriesAndMatchingEvents(sessionState, eventRecordEntries, matchingEvents);
+            return;
+        }
+
+        ensureVersionInMetadata(sessionState.getMetadata());
+        prepareHAStatsForPersist();
+
+        List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(eventRecordEntries);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null && !matchingEvents.isEmpty()) {
+            for (MatchingEvent me : matchingEvents) {
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, HAStats, EventRecord snapshot, and matching events", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            doHAStatsUpsert(conn);
+            replaceEventRecordEntries(conn, sessionState.getRuleSetName(), preparedEventRecordEntries);
+
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+    }
+
     private void validateForPersist(SessionState sessionState) {
         validateSessionStateForPersist(sessionState, isLeader);
     }
@@ -357,11 +500,17 @@ public class H2StateManager extends AbstractHAStateManager {
     }
 
     private void doSessionStateUpsert(Connection conn, SessionState sessionState) throws SQLException {
-        String encryptedPartialEvents = null;
-        if (sessionState.getPartialEvents() != null) {
-            encryptedPartialEvents = encryptIfEnabled(toJson(sessionState.getPartialEvents()));
+        doSessionStateUpsert(conn, sessionState, prepareSessionPartialEventsForPersist(sessionState));
+    }
+
+    private String prepareSessionPartialEventsForPersist(SessionState sessionState) {
+        if (sessionState.getEventRecordsManifestSHA() != null) {
+            return null;
         }
-        doSessionStateUpsert(conn, sessionState, encryptedPartialEvents);
+        if (sessionState.getPartialEvents() != null) {
+            return encryptIfEnabled(toJson(sessionState.getPartialEvents()));
+        }
+        return null;
     }
 
     private void doSessionStateUpsert(Connection conn, SessionState sessionState, String encryptedPartialEvents) throws SQLException {
@@ -408,6 +557,110 @@ public class H2StateManager extends AbstractHAStateManager {
 
             ps.executeUpdate();
         }
+    }
+
+    private void doEventRecordUpsert(Connection conn, String ruleSetName, EventRecordEntry entry,
+                                     String encryptedEventJson, String eventRecordSha) throws SQLException {
+        EventRecord record = entry.getRecord();
+        String sql = "MERGE INTO " + EVENT_RECORD
+                + " (ha_uuid, rule_set_name, record_identifier, inserted_at, record_sequence, record_type,"
+                + " event_json, expiration_duration, event_record_sha, metadata, properties, settings, ext)"
+                + " KEY(ha_uuid, rule_set_name, record_identifier)"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '{}', '{}', '{}', '{}')";
+
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.setString(3, entry.getRecordIdentifier());
+            ps.setLong(4, record.getInsertedAt());
+            ps.setLong(5, entry.getRecordSequence());
+            ps.setString(6, record.getRecordType().name());
+            ps.setString(7, encryptedEventJson);
+            if (record.getExpirationDuration() == null) {
+                ps.setObject(8, null);
+            } else {
+                ps.setLong(8, record.getExpirationDuration());
+            }
+            ps.setString(9, eventRecordSha);
+            ps.executeUpdate();
+        }
+    }
+
+    private void doEventRecordDelete(Connection conn, String ruleSetName, String recordIdentifier) throws SQLException {
+        String sql = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ? AND record_identifier = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.setString(3, recordIdentifier);
+            ps.executeUpdate();
+        }
+    }
+
+    private EventRecordEntry readEventRecordEntry(ResultSet rs) throws SQLException {
+        String recordIdentifier = rs.getString("record_identifier");
+        long insertedAt = rs.getLong("inserted_at");
+        long recordSequence = rs.getLong("record_sequence");
+        EventRecord.RecordType recordType = EventRecord.RecordType.valueOf(rs.getString("record_type"));
+        String eventJson = decryptIfEnabled(rs.getString("event_json"));
+        long expirationDurationValue = rs.getLong("expiration_duration");
+        Long expirationDuration = rs.wasNull() ? null : expirationDurationValue;
+        return new EventRecordEntry(recordIdentifier, recordSequence, new EventRecord(eventJson, insertedAt, recordType, expirationDuration),
+                                    rs.getString("event_record_sha"));
+    }
+
+    private List<PreparedEventRecordChange> prepareEventRecordChanges(List<EventRecordChange> eventRecordChanges) {
+        List<PreparedEventRecordChange> preparedChanges = new ArrayList<>();
+        if (eventRecordChanges == null || eventRecordChanges.isEmpty()) {
+            return preparedChanges;
+        }
+        for (EventRecordChange change : eventRecordChanges) {
+            if (change.getType() == EventRecordChange.Type.UPSERT) {
+                EventRecordEntry entry = change.getEntry();
+                String eventRecordSHA = entry.getEventRecordSHA() != null ? entry.getEventRecordSHA() : calculateEventRecordSHA(entry);
+                preparedChanges.add(new PreparedEventRecordChange(change, encryptIfEnabled(entry.getRecord().getEventJson()), eventRecordSHA));
+            } else {
+                preparedChanges.add(new PreparedEventRecordChange(change, null, null));
+            }
+        }
+        return preparedChanges;
+    }
+
+    private List<PreparedEventRecordEntry> prepareEventRecordEntries(List<EventRecordEntry> eventRecordEntries) {
+        List<PreparedEventRecordEntry> preparedEntries = new ArrayList<>();
+        if (eventRecordEntries == null || eventRecordEntries.isEmpty()) {
+            return preparedEntries;
+        }
+        for (EventRecordEntry entry : eventRecordEntries) {
+            String eventRecordSHA = entry.getEventRecordSHA() != null ? entry.getEventRecordSHA() : calculateEventRecordSHA(entry);
+            preparedEntries.add(new PreparedEventRecordEntry(entry, encryptIfEnabled(entry.getRecord().getEventJson()), eventRecordSHA));
+        }
+        return preparedEntries;
+    }
+
+    private void applyEventRecordChanges(Connection conn, String ruleSetName, List<PreparedEventRecordChange> preparedChanges) throws SQLException {
+        for (PreparedEventRecordChange preparedChange : preparedChanges) {
+            if (preparedChange.change().getType() == EventRecordChange.Type.UPSERT) {
+                doEventRecordUpsert(conn, ruleSetName, preparedChange.change().getEntry(), preparedChange.encryptedEventJson(), preparedChange.eventRecordSha());
+            } else {
+                doEventRecordDelete(conn, ruleSetName, preparedChange.change().getRecordIdentifier());
+            }
+        }
+    }
+
+    private void replaceEventRecordEntries(Connection conn, String ruleSetName, List<PreparedEventRecordEntry> preparedEntries) throws SQLException {
+        String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+        try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.executeUpdate();
+        }
+
+        for (PreparedEventRecordEntry preparedEntry : preparedEntries) {
+            doEventRecordUpsert(conn, ruleSetName, preparedEntry.entry(), preparedEntry.encryptedEventJson(), preparedEntry.eventRecordSha());
+        }
+    }
+
+    private record PreparedEventRecordEntry(EventRecordEntry entry, String encryptedEventJson, String eventRecordSha) {
     }
 
     // ── MatchingEvent operations ────────────────────────────────────────
@@ -675,8 +928,15 @@ public class H2StateManager extends AbstractHAStateManager {
         }
 
         executeInTransaction("Failed to delete SessionState", conn -> {
-            String sql = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+            try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+                ps.setString(1, haUuid);
+                ps.setString(2, ruleSetName);
+                ps.executeUpdate();
+            }
+
+            String deleteSessionState = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
+            try (PreparedStatement ps = conn.prepareStatement(deleteSessionState)) {
                 ps.setString(1, haUuid);
                 ps.setString(2, ruleSetName);
                 ps.executeUpdate();
@@ -719,7 +979,79 @@ public class H2StateManager extends AbstractHAStateManager {
     }
 
     @Override
+    public void persistSessionStateEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                                 List<EventRecordChange> eventRecordChanges,
+                                                                 List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+        ensureVersionInMetadata(sessionState.getMetadata());
+
+        List<PreparedEventRecordChange> preparedEventRecordChanges = prepareEventRecordChanges(eventRecordChanges);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null) {
+            for (MatchingEvent me : matchingEvents) {
+                if (me.getMeUuid() == null) {
+                    me.setMeUuid(UUID.randomUUID().toString());
+                }
+                if (me.getCreatedAt() == 0L) {
+                    me.setCreatedAt(System.currentTimeMillis());
+                }
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, EventRecord changes, and matching events", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            applyEventRecordChanges(conn, sessionState.getRuleSetName(), preparedEventRecordChanges);
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+
+        logger.debug("Persisted SessionState, {} EventRecord changes, and {} matching events in single transaction for haUuid: {}",
+                     eventRecordChanges != null ? eventRecordChanges.size() : 0,
+                     matchingEvents != null ? matchingEvents.size() : 0,
+                     haUuid);
+    }
+
+    @Override
+    public void persistSessionStateEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                       List<EventRecordEntry> eventRecordEntries,
+                                                                       List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+        ensureVersionInMetadata(sessionState.getMetadata());
+
+        List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(eventRecordEntries);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null) {
+            for (MatchingEvent me : matchingEvents) {
+                if (me.getMeUuid() == null) {
+                    me.setMeUuid(UUID.randomUUID().toString());
+                }
+                if (me.getCreatedAt() == 0L) {
+                    me.setCreatedAt(System.currentTimeMillis());
+                }
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, EventRecord snapshot, and matching events", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            replaceEventRecordEntries(conn, sessionState.getRuleSetName(), preparedEventRecordEntries);
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+    }
+
+    @Override
     public void persistLeaderStartup(List<SessionState> sessionStatesToPersist,
+                                     Map<String, List<EventRecordEntry>> eventRecordEntriesByRuleSet,
                                      List<String> rulesetNamesToDelete,
                                      List<MatchingEvent> matchingEvents) {
         // Pre-transaction: validate, encrypt, assign UUIDs
@@ -750,9 +1082,16 @@ public class H2StateManager extends AbstractHAStateManager {
 
             // 2. Delete old session states (hash-mismatch rulesets)
             if (rulesetNamesToDelete != null) {
-                String deleteSql = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
                 for (String rulesetName : rulesetNamesToDelete) {
-                    try (PreparedStatement ps = conn.prepareStatement(deleteSql)) {
+                    String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+                    try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+                        ps.setString(1, haUuid);
+                        ps.setString(2, rulesetName);
+                        ps.executeUpdate();
+                    }
+
+                    String deleteSessionState = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
+                    try (PreparedStatement ps = conn.prepareStatement(deleteSessionState)) {
                         ps.setString(1, haUuid);
                         ps.setString(2, rulesetName);
                         ps.executeUpdate();
@@ -763,6 +1102,12 @@ public class H2StateManager extends AbstractHAStateManager {
             // 3. Upsert all refreshed session states
             for (SessionState ss : sessionStatesToPersist) {
                 doSessionStateUpsert(conn, ss);
+                boolean hasSnapshot = eventRecordEntriesByRuleSet != null && eventRecordEntriesByRuleSet.containsKey(ss.getRuleSetName());
+                if (ss.getEventRecordsManifestSHA() != null || hasSnapshot) {
+                    List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(
+                            hasSnapshot ? eventRecordEntriesByRuleSet.get(ss.getRuleSetName()) : null);
+                    replaceEventRecordEntries(conn, ss.getRuleSetName(), preparedEventRecordEntries);
+                }
             }
 
             // 4. Insert all recovery matching events

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLSchema.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLSchema.java
@@ -1,8 +1,10 @@
 package org.drools.ansible.rulebook.integration.ha.postgres;
 
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.ACTION_INFO;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.EVENT_RECORD;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.HA_STATS;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_ACTION_INFO_ME;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_EVENT_RECORD_ORDER;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.IDX_MATCHING_EVENT_HA_UUID;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.MATCHING_EVENT;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.SESSION_STATE;
@@ -61,6 +63,30 @@ public class PostgreSQLSchema {
                         + "UNIQUE(ha_uuid, rule_set_name)"
                         + ")";
                 stmt.execute(createSessionStateTable);
+
+                String createEventRecordTable =
+                        "CREATE TABLE IF NOT EXISTS " + EVENT_RECORD + " ("
+                        + "ha_uuid VARCHAR(255) NOT NULL, "
+                        + "rule_set_name VARCHAR(255) NOT NULL, "
+                        + "record_identifier VARCHAR(255) NOT NULL, "
+                        + "inserted_at BIGINT NOT NULL, "
+                        + "record_sequence BIGINT NOT NULL, "
+                        + "record_type VARCHAR(64) NOT NULL, "
+                        + "event_json TEXT, "
+                        + "expiration_duration BIGINT, "
+                        + "event_record_sha VARCHAR(64) NOT NULL, "
+                        + "metadata JSONB DEFAULT '{}'::jsonb, "
+                        + "properties JSONB DEFAULT '{}'::jsonb, "
+                        + "settings JSONB DEFAULT '{}'::jsonb, "
+                        + "ext JSONB DEFAULT '{}'::jsonb, "
+                        + "PRIMARY KEY (ha_uuid, rule_set_name, record_identifier)"
+                        + ")";
+                stmt.execute(createEventRecordTable);
+
+                String createEventRecordOrderIndex =
+                        "CREATE INDEX IF NOT EXISTS " + IDX_EVENT_RECORD_ORDER
+                        + " ON " + EVENT_RECORD + "(ha_uuid, rule_set_name, inserted_at, record_sequence, record_identifier)";
+                stmt.execute(createEventRecordOrderIndex);
 
                 // Create MatchingEvent table
                 // PostgreSQL differences from H2:
@@ -164,6 +190,25 @@ public class PostgreSQLSchema {
                     }
                 }
 
+                stmt.execute("CREATE TABLE IF NOT EXISTS " + EVENT_RECORD + " ("
+                        + "ha_uuid VARCHAR(255) NOT NULL, "
+                        + "rule_set_name VARCHAR(255) NOT NULL, "
+                        + "record_identifier VARCHAR(255) NOT NULL, "
+                        + "inserted_at BIGINT NOT NULL, "
+                        + "record_sequence BIGINT NOT NULL, "
+                        + "record_type VARCHAR(64) NOT NULL, "
+                        + "event_json TEXT, "
+                        + "expiration_duration BIGINT, "
+                        + "event_record_sha VARCHAR(64) NOT NULL, "
+                        + "metadata JSONB DEFAULT '{}'::jsonb, "
+                        + "properties JSONB DEFAULT '{}'::jsonb, "
+                        + "settings JSONB DEFAULT '{}'::jsonb, "
+                        + "ext JSONB DEFAULT '{}'::jsonb, "
+                        + "PRIMARY KEY (ha_uuid, rule_set_name, record_identifier)"
+                        + ")");
+                stmt.execute("CREATE INDEX IF NOT EXISTS " + IDX_EVENT_RECORD_ORDER
+                        + " ON " + EVENT_RECORD + "(ha_uuid, rule_set_name, inserted_at, record_sequence, record_identifier)");
+
                 // Migration: drop version column and update UNIQUE constraint
                 // Step 1: Drop old constraint (PG naming convention: table_col1_col2_..._key)
                 stmt.execute("ALTER TABLE " + SESSION_STATE + " DROP CONSTRAINT IF EXISTS " + SESSION_STATE + "_ha_uuid_rule_set_name_version_key");
@@ -193,6 +238,7 @@ public class PostgreSQLSchema {
                 // Drop in reverse order due to foreign keys
                 stmt.execute("DROP TABLE IF EXISTS " + ACTION_INFO + " CASCADE");
                 stmt.execute("DROP TABLE IF EXISTS " + MATCHING_EVENT + " CASCADE");
+                stmt.execute("DROP TABLE IF EXISTS " + EVENT_RECORD + " CASCADE");
                 stmt.execute("DROP TABLE IF EXISTS " + SESSION_STATE + " CASCADE");
                 stmt.execute("DROP TABLE IF EXISTS " + HA_STATS + " CASCADE");
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLStateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLStateManager.java
@@ -22,10 +22,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.drools.ansible.rulebook.integration.ha.api.AbstractHAStateManager;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.drools.ansible.rulebook.integration.ha.model.HAStats;
 import org.drools.ansible.rulebook.integration.ha.model.MatchingEvent;
 import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +36,11 @@ import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValu
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValue;
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.toJson;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.ACTION_INFO;
+import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.EVENT_RECORD;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.HA_STATS;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.MATCHING_EVENT;
 import static org.drools.ansible.rulebook.integration.ha.api.HATableNames.SESSION_STATE;
+import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.calculateEventRecordSHA;
 
 /**
  * PostgreSQL implementation of HAStateManager with production-ready persistence
@@ -339,13 +344,26 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
                 sessionState.setRuleSetName(rs.getString("rule_set_name"));
                 sessionState.setRulebookHash(rs.getString("rulebook_hash"));
 
-                String partialEventsJson = decryptIfEnabled(rs.getString("partial_matching_events"));
-                if (partialEventsJson != null) {
-                    try {
-                        List<EventRecord> partialEvents = OBJECT_MAPPER.readValue(partialEventsJson, EVENT_RECORD_LIST_TYPE);
-                        sessionState.setPartialEvents(partialEvents);
-                    } catch (Exception e) {
-                        logger.error("Failed to deserialize partial events", e);
+                List<EventRecordEntry> eventRecordEntries = getPersistedEventRecords(ruleSetName);
+                if (!eventRecordEntries.isEmpty()) {
+                    sessionState.setPartialEvents(eventRecordEntries.stream()
+                                                          .map(EventRecordEntry::getRecord)
+                                                          .toList());
+                    sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(eventRecordEntries));
+                } else {
+                    String encryptedPartialEvents = rs.getString("partial_matching_events");
+                    if (encryptedPartialEvents != null) {
+                        String partialEventsJson = decryptIfEnabled(encryptedPartialEvents);
+                        try {
+                            List<EventRecord> partialEvents = OBJECT_MAPPER.readValue(partialEventsJson, EVENT_RECORD_LIST_TYPE);
+                            sessionState.setPartialEvents(partialEvents);
+                        } catch (Exception e) {
+                            logger.error("Failed to deserialize partial events", e);
+                        }
+                        sessionState.setEventRecordsManifestSHA(null);
+                    } else {
+                        sessionState.setPartialEvents(new ArrayList<>());
+                        sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(List.of()));
                     }
                 }
 
@@ -401,6 +419,57 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
     }
 
     @Override
+    public void persistEventRecordChanges(String ruleSetName, List<EventRecordChange> eventRecordChanges) {
+        if (!isLeader) {
+            throw new IllegalStateException("Cannot persist EventRecord changes - not leader");
+        }
+        if (eventRecordChanges == null || eventRecordChanges.isEmpty()) {
+            return;
+        }
+
+        List<PreparedEventRecordChange> preparedChanges = prepareEventRecordChanges(eventRecordChanges);
+
+        executeInTransaction("Failed to persist EventRecord changes to PostgreSQL", conn -> {
+            applyEventRecordChanges(conn, ruleSetName, preparedChanges);
+        });
+    }
+
+    @Override
+    public List<EventRecordEntry> getPersistedEventRecords(String ruleSetName) {
+        String sql = "SELECT record_identifier, inserted_at, record_sequence, record_type, event_json, expiration_duration, event_record_sha"
+                + " FROM " + EVENT_RECORD
+                + " WHERE ha_uuid = ? AND rule_set_name = ?"
+                + " ORDER BY record_sequence, record_identifier";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+
+            List<EventRecordEntry> entries = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    EventRecordEntry entry = readEventRecordEntry(rs);
+                    String persistedSha = rs.getString("event_record_sha");
+                    String calculatedSha = calculateEventRecordSHA(entry);
+                    if (!persistedSha.equals(calculatedSha)) {
+                        throw new IllegalStateException("EventRecord SHA mismatch for ruleSetName=" + ruleSetName
+                                                                + ", recordIdentifier=" + entry.getRecordIdentifier());
+                    }
+                    entries.add(entry);
+                }
+            }
+            return entries;
+        } catch (SQLException e) {
+            logger.error("Failed to get EventRecord rows from PostgreSQL", e);
+            throw new RuntimeException("Failed to get EventRecord rows from PostgreSQL", e);
+        }
+    }
+
+    private record PreparedEventRecordChange(EventRecordChange change, String encryptedEventJson, String eventRecordSha) {
+    }
+
+    @Override
     public void persistSessionStateAndStats(SessionState sessionState) {
         validateForPersist(sessionState);
 
@@ -438,10 +507,7 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
         prepareHAStatsForPersist();
 
         // Pre-compute encrypted data outside the transaction to minimize lock duration
-        String encryptedPartialEvents = null;
-        if (sessionState.getPartialEvents() != null) {
-            encryptedPartialEvents = encryptIfEnabled(toJson(sessionState.getPartialEvents()));
-        }
+        String encryptedPartialEvents = prepareSessionPartialEventsForPersist(sessionState);
 
         List<String> encryptedEventDataList = new ArrayList<>();
         List<UUID> meUuids = new ArrayList<>();
@@ -467,6 +533,87 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
                      matchingEvents.size(), haUuid);
     }
 
+    @Override
+    public void persistSessionStateStatsEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                                      List<EventRecordChange> eventRecordChanges,
+                                                                      List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+
+        if (haStats == null) {
+            persistSessionStateEventRecordsAndMatchingEvents(sessionState, eventRecordChanges, matchingEvents);
+            return;
+        }
+
+        ensureVersionInMetadata(sessionState.getMetadata());
+        prepareHAStatsForPersist();
+
+        List<PreparedEventRecordChange> preparedEventRecordChanges = prepareEventRecordChanges(eventRecordChanges);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        List<UUID> meUuids = new ArrayList<>();
+        if (matchingEvents != null && !matchingEvents.isEmpty()) {
+            for (MatchingEvent me : matchingEvents) {
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+                meUuids.add(UUID.fromString(me.getMeUuid()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, HAStats, EventRecord changes, and matching events to PostgreSQL", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            doHAStatsUpsert(conn);
+            applyEventRecordChanges(conn, sessionState.getRuleSetName(), preparedEventRecordChanges);
+
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), meUuids.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+
+        logger.debug("Persisted SessionState, HAStats, {} EventRecord changes, and {} matching events to PostgreSQL in single transaction for haUuid: {}",
+                     eventRecordChanges != null ? eventRecordChanges.size() : 0,
+                     matchingEvents != null ? matchingEvents.size() : 0,
+                     haUuid);
+    }
+
+    @Override
+    public void persistSessionStateStatsEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                            List<EventRecordEntry> eventRecordEntries,
+                                                                            List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+
+        if (haStats == null) {
+            persistSessionStateEventRecordEntriesAndMatchingEvents(sessionState, eventRecordEntries, matchingEvents);
+            return;
+        }
+
+        ensureVersionInMetadata(sessionState.getMetadata());
+        prepareHAStatsForPersist();
+
+        List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(eventRecordEntries);
+        List<String> encryptedEventDataList = new ArrayList<>();
+        List<UUID> meUuids = new ArrayList<>();
+        if (matchingEvents != null && !matchingEvents.isEmpty()) {
+            for (MatchingEvent me : matchingEvents) {
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+                meUuids.add(UUID.fromString(me.getMeUuid()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, HAStats, EventRecord snapshot, and matching events to PostgreSQL", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            doHAStatsUpsert(conn);
+            replaceEventRecordEntries(conn, sessionState.getRuleSetName(), preparedEventRecordEntries);
+
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), meUuids.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+    }
+
     private void validateForPersist(SessionState sessionState) {
         validateSessionStateForPersist(sessionState, isLeader);
     }
@@ -479,11 +626,17 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
     }
 
     private void doSessionStateUpsert(Connection conn, SessionState sessionState) throws SQLException {
-        String encryptedPartialEvents = null;
-        if (sessionState.getPartialEvents() != null) {
-            encryptedPartialEvents = encryptIfEnabled(toJson(sessionState.getPartialEvents()));
+        doSessionStateUpsert(conn, sessionState, prepareSessionPartialEventsForPersist(sessionState));
+    }
+
+    private String prepareSessionPartialEventsForPersist(SessionState sessionState) {
+        if (sessionState.getEventRecordsManifestSHA() != null) {
+            return null;
         }
-        doSessionStateUpsert(conn, sessionState, encryptedPartialEvents);
+        if (sessionState.getPartialEvents() != null) {
+            return encryptIfEnabled(toJson(sessionState.getPartialEvents()));
+        }
+        return null;
     }
 
     private void doSessionStateUpsert(Connection conn, SessionState sessionState, String encryptedPartialEvents) throws SQLException {
@@ -535,6 +688,120 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
 
             ps.executeUpdate();
         }
+    }
+
+    private void doEventRecordUpsert(Connection conn, String ruleSetName, EventRecordEntry entry,
+                                     String encryptedEventJson, String eventRecordSha) throws SQLException {
+        EventRecord record = entry.getRecord();
+        String sql = "INSERT INTO " + EVENT_RECORD
+                + " (ha_uuid, rule_set_name, record_identifier, inserted_at, record_sequence, record_type,"
+                + " event_json, expiration_duration, event_record_sha, metadata, properties, settings, ext)"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb)"
+                + " ON CONFLICT (ha_uuid, rule_set_name, record_identifier) DO UPDATE SET"
+                + " inserted_at = EXCLUDED.inserted_at,"
+                + " record_sequence = EXCLUDED.record_sequence,"
+                + " record_type = EXCLUDED.record_type,"
+                + " event_json = EXCLUDED.event_json,"
+                + " expiration_duration = EXCLUDED.expiration_duration,"
+                + " event_record_sha = EXCLUDED.event_record_sha,"
+                + " metadata = EXCLUDED.metadata,"
+                + " properties = EXCLUDED.properties,"
+                + " settings = EXCLUDED.settings,"
+                + " ext = EXCLUDED.ext";
+
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.setString(3, entry.getRecordIdentifier());
+            ps.setLong(4, record.getInsertedAt());
+            ps.setLong(5, entry.getRecordSequence());
+            ps.setString(6, record.getRecordType().name());
+            ps.setString(7, encryptedEventJson);
+            if (record.getExpirationDuration() == null) {
+                ps.setObject(8, null);
+            } else {
+                ps.setLong(8, record.getExpirationDuration());
+            }
+            ps.setString(9, eventRecordSha);
+            ps.executeUpdate();
+        }
+    }
+
+    private void doEventRecordDelete(Connection conn, String ruleSetName, String recordIdentifier) throws SQLException {
+        String sql = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ? AND record_identifier = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.setString(3, recordIdentifier);
+            ps.executeUpdate();
+        }
+    }
+
+    private EventRecordEntry readEventRecordEntry(ResultSet rs) throws SQLException {
+        String recordIdentifier = rs.getString("record_identifier");
+        long insertedAt = rs.getLong("inserted_at");
+        long recordSequence = rs.getLong("record_sequence");
+        EventRecord.RecordType recordType = EventRecord.RecordType.valueOf(rs.getString("record_type"));
+        String eventJson = decryptIfEnabled(rs.getString("event_json"));
+        long expirationDurationValue = rs.getLong("expiration_duration");
+        Long expirationDuration = rs.wasNull() ? null : expirationDurationValue;
+        return new EventRecordEntry(recordIdentifier, recordSequence, new EventRecord(eventJson, insertedAt, recordType, expirationDuration),
+                                    rs.getString("event_record_sha"));
+    }
+
+    private List<PreparedEventRecordChange> prepareEventRecordChanges(List<EventRecordChange> eventRecordChanges) {
+        List<PreparedEventRecordChange> preparedChanges = new ArrayList<>();
+        if (eventRecordChanges == null || eventRecordChanges.isEmpty()) {
+            return preparedChanges;
+        }
+        for (EventRecordChange change : eventRecordChanges) {
+            if (change.getType() == EventRecordChange.Type.UPSERT) {
+                EventRecordEntry entry = change.getEntry();
+                String eventRecordSHA = entry.getEventRecordSHA() != null ? entry.getEventRecordSHA() : calculateEventRecordSHA(entry);
+                preparedChanges.add(new PreparedEventRecordChange(change, encryptIfEnabled(entry.getRecord().getEventJson()), eventRecordSHA));
+            } else {
+                preparedChanges.add(new PreparedEventRecordChange(change, null, null));
+            }
+        }
+        return preparedChanges;
+    }
+
+    private List<PreparedEventRecordEntry> prepareEventRecordEntries(List<EventRecordEntry> eventRecordEntries) {
+        List<PreparedEventRecordEntry> preparedEntries = new ArrayList<>();
+        if (eventRecordEntries == null || eventRecordEntries.isEmpty()) {
+            return preparedEntries;
+        }
+        for (EventRecordEntry entry : eventRecordEntries) {
+            String eventRecordSHA = entry.getEventRecordSHA() != null ? entry.getEventRecordSHA() : calculateEventRecordSHA(entry);
+            preparedEntries.add(new PreparedEventRecordEntry(entry, encryptIfEnabled(entry.getRecord().getEventJson()), eventRecordSHA));
+        }
+        return preparedEntries;
+    }
+
+    private void applyEventRecordChanges(Connection conn, String ruleSetName, List<PreparedEventRecordChange> preparedChanges) throws SQLException {
+        for (PreparedEventRecordChange preparedChange : preparedChanges) {
+            if (preparedChange.change().getType() == EventRecordChange.Type.UPSERT) {
+                doEventRecordUpsert(conn, ruleSetName, preparedChange.change().getEntry(), preparedChange.encryptedEventJson(), preparedChange.eventRecordSha());
+            } else {
+                doEventRecordDelete(conn, ruleSetName, preparedChange.change().getRecordIdentifier());
+            }
+        }
+    }
+
+    private void replaceEventRecordEntries(Connection conn, String ruleSetName, List<PreparedEventRecordEntry> preparedEntries) throws SQLException {
+        String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+        try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+            ps.setString(1, haUuid);
+            ps.setString(2, ruleSetName);
+            ps.executeUpdate();
+        }
+
+        for (PreparedEventRecordEntry preparedEntry : preparedEntries) {
+            doEventRecordUpsert(conn, ruleSetName, preparedEntry.entry(), preparedEntry.encryptedEventJson(), preparedEntry.eventRecordSha());
+        }
+    }
+
+    private record PreparedEventRecordEntry(EventRecordEntry entry, String encryptedEventJson, String eventRecordSha) {
     }
 
     // ── MatchingEvent operations ────────────────────────────────────────
@@ -809,8 +1076,15 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
         }
 
         executeInTransaction("Failed to delete SessionState from PostgreSQL", conn -> {
-            String sql = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+            try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+                ps.setString(1, haUuid);
+                ps.setString(2, ruleSetName);
+                ps.executeUpdate();
+            }
+
+            String deleteSessionState = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
+            try (PreparedStatement ps = conn.prepareStatement(deleteSessionState)) {
                 ps.setString(1, haUuid);
                 ps.setString(2, ruleSetName);
                 ps.executeUpdate();
@@ -854,7 +1128,81 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
     }
 
     @Override
+    public void persistSessionStateEventRecordsAndMatchingEvents(SessionState sessionState,
+                                                                 List<EventRecordChange> eventRecordChanges,
+                                                                 List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+        ensureVersionInMetadata(sessionState.getMetadata());
+
+        List<PreparedEventRecordChange> preparedEventRecordChanges = prepareEventRecordChanges(eventRecordChanges);
+        List<UUID> meUuids = new ArrayList<>();
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null) {
+            for (MatchingEvent me : matchingEvents) {
+                UUID meUuid = UUID.randomUUID();
+                meUuids.add(meUuid);
+                me.setMeUuid(meUuid.toString());
+                if (me.getCreatedAt() == 0L) {
+                    me.setCreatedAt(System.currentTimeMillis());
+                }
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, EventRecord changes, and matching events in PostgreSQL", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            applyEventRecordChanges(conn, sessionState.getRuleSetName(), preparedEventRecordChanges);
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), meUuids.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+
+        logger.debug("Persisted SessionState, {} EventRecord changes, and {} matching events in single transaction for haUuid: {}",
+                     eventRecordChanges != null ? eventRecordChanges.size() : 0,
+                     matchingEvents != null ? matchingEvents.size() : 0,
+                     haUuid);
+    }
+
+    @Override
+    public void persistSessionStateEventRecordEntriesAndMatchingEvents(SessionState sessionState,
+                                                                       List<EventRecordEntry> eventRecordEntries,
+                                                                       List<MatchingEvent> matchingEvents) {
+        validateForPersist(sessionState);
+        ensureVersionInMetadata(sessionState.getMetadata());
+
+        List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(eventRecordEntries);
+        List<UUID> meUuids = new ArrayList<>();
+        List<String> encryptedEventDataList = new ArrayList<>();
+        if (matchingEvents != null) {
+            for (MatchingEvent me : matchingEvents) {
+                UUID meUuid = UUID.randomUUID();
+                meUuids.add(meUuid);
+                me.setMeUuid(meUuid.toString());
+                if (me.getCreatedAt() == 0L) {
+                    me.setCreatedAt(System.currentTimeMillis());
+                }
+                ensureVersionInMetadata(me.getMetadata());
+                encryptedEventDataList.add(encryptIfEnabled(me.getEventData()));
+            }
+        }
+
+        executeInTransaction("Failed to persist SessionState, EventRecord snapshot, and matching events in PostgreSQL", conn -> {
+            doSessionStateUpsert(conn, sessionState, null);
+            replaceEventRecordEntries(conn, sessionState.getRuleSetName(), preparedEventRecordEntries);
+            if (matchingEvents != null) {
+                for (int i = 0; i < matchingEvents.size(); i++) {
+                    doMatchingEventInsert(conn, matchingEvents.get(i), meUuids.get(i), encryptedEventDataList.get(i));
+                }
+            }
+        });
+    }
+
+    @Override
     public void persistLeaderStartup(List<SessionState> sessionStatesToPersist,
+                                     Map<String, List<EventRecordEntry>> eventRecordEntriesByRuleSet,
                                      List<String> rulesetNamesToDelete,
                                      List<MatchingEvent> matchingEvents) {
         // Pre-transaction: validate, encrypt, assign UUIDs
@@ -886,9 +1234,16 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
 
             // 2. Delete old session states (hash-mismatch rulesets)
             if (rulesetNamesToDelete != null) {
-                String deleteSql = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
                 for (String rulesetName : rulesetNamesToDelete) {
-                    try (PreparedStatement ps = conn.prepareStatement(deleteSql)) {
+                    String deleteEventRecords = "DELETE FROM " + EVENT_RECORD + " WHERE ha_uuid = ? AND rule_set_name = ?";
+                    try (PreparedStatement ps = conn.prepareStatement(deleteEventRecords)) {
+                        ps.setString(1, haUuid);
+                        ps.setString(2, rulesetName);
+                        ps.executeUpdate();
+                    }
+
+                    String deleteSessionState = "DELETE FROM " + SESSION_STATE + " WHERE ha_uuid = ? AND rule_set_name = ?";
+                    try (PreparedStatement ps = conn.prepareStatement(deleteSessionState)) {
                         ps.setString(1, haUuid);
                         ps.setString(2, rulesetName);
                         ps.executeUpdate();
@@ -899,6 +1254,12 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
             // 3. Upsert all refreshed session states
             for (SessionState ss : sessionStatesToPersist) {
                 doSessionStateUpsert(conn, ss);
+                boolean hasSnapshot = eventRecordEntriesByRuleSet != null && eventRecordEntriesByRuleSet.containsKey(ss.getRuleSetName());
+                if (ss.getEventRecordsManifestSHA() != null || hasSnapshot) {
+                    List<PreparedEventRecordEntry> preparedEventRecordEntries = prepareEventRecordEntries(
+                            hasSnapshot ? eventRecordEntriesByRuleSet.get(ss.getRuleSetName()) : null);
+                    replaceEventRecordEntries(conn, ss.getRuleSetName(), preparedEventRecordEntries);
+                }
             }
 
             // 4. Insert all recovery matching events

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/DroolsVersionStalenessTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/DroolsVersionStalenessTest.java
@@ -29,11 +29,11 @@ class DroolsVersionStalenessTest {
     void droolsVersionIsNotBehindLatestGitTag() throws Exception {
         String latestTag = getLatestVersionTag();
         assumeTrue(latestTag != null,
-                "Skipping: no version-like git tags found (shallow clone or tags not fetched)");
+                   "Skipping: no version-like git tags found (shallow clone or tags not fetched)");
 
         assertThat(compareVersions(AbstractHAStateManager.DROOLS_VERSION, latestTag))
                 .as("DROOLS_VERSION is stale! Latest git tag is '%s' but code has '%s'. "
-                    + "Update AbstractHAStateManager.DROOLS_VERSION to be >= the latest tag.",
+                            + "Update AbstractHAStateManager.DROOLS_VERSION to be >= the latest tag.",
                     latestTag, AbstractHAStateManager.DROOLS_VERSION)
                 .isGreaterThanOrEqualTo(0);
     }

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/HAEventRecordContextTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/HAEventRecordContextTest.java
@@ -1,0 +1,87 @@
+package org.drools.ansible.rulebook.integration.ha.tests;
+
+import java.util.List;
+
+import org.drools.ansible.rulebook.integration.ha.api.HASessionContext;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HAEventRecordContextTest {
+
+    @Test
+    void tracksEventRecordDeltasWithStableSequences() {
+        HASessionContext context = new HASessionContext();
+        EventRecord first = new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT);
+        EventRecord second = new EventRecord("{\"j\":2}", 1_000L, EventRecord.RecordType.FACT);
+
+        context.addTrackedRecord("event-1", first, 10L);
+        context.addTrackedRecord("fact-1", second, 11L);
+
+        List<EventRecordChange> insertChanges = context.drainEventRecordChanges();
+
+        assertThat(insertChanges).hasSize(2);
+        assertThat(insertChanges).extracting(EventRecordChange::getType)
+                .containsExactly(EventRecordChange.Type.UPSERT, EventRecordChange.Type.UPSERT);
+        assertThat(insertChanges).extracting(EventRecordChange::getRecordIdentifier)
+                .containsExactly("event-1", "fact-1");
+        assertThat(insertChanges).extracting(change -> change.getEntry().getRecordSequence())
+                .containsExactly(0L, 1L);
+        assertThat(context.drainEventRecordChanges()).isEmpty();
+
+        context.updateTrackedRecordByFactHandle(10L, "{\"i\":10}");
+
+        List<EventRecordChange> updateChanges = context.drainEventRecordChanges();
+
+        assertThat(updateChanges).hasSize(1);
+        assertThat(updateChanges.get(0).getType()).isEqualTo(EventRecordChange.Type.UPSERT);
+        assertThat(updateChanges.get(0).getRecordIdentifier()).isEqualTo("event-1");
+        assertThat(updateChanges.get(0).getEntry().getRecordSequence()).isEqualTo(0L);
+        assertThat(updateChanges.get(0).getEntry().getRecord().getEventJson()).isEqualTo("{\"i\":10}");
+
+        context.removeTrackedRecordByFactHandle(10L);
+
+        List<EventRecordChange> deleteChanges = context.drainEventRecordChanges();
+
+        assertThat(deleteChanges).hasSize(1);
+        assertThat(deleteChanges.get(0).getType()).isEqualTo(EventRecordChange.Type.DELETE);
+        assertThat(deleteChanges.get(0).getRecordIdentifier()).isEqualTo("event-1");
+
+        List<EventRecordEntry> snapshot = context.snapshotEventRecordEntries();
+
+        assertThat(snapshot).hasSize(1);
+        assertThat(snapshot.get(0).getRecordIdentifier()).isEqualTo("fact-1");
+        assertThat(snapshot.get(0).getRecordSequence()).isEqualTo(1L);
+    }
+
+    @Test
+    void eventRecordHashesAreDeterministicAndCanonicalBySequence() {
+        EventRecordEntry first = new EventRecordEntry(
+                "event-1",
+                0L,
+                new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT));
+        EventRecordEntry second = new EventRecordEntry(
+                "event-2",
+                1L,
+                new EventRecord("{\"j\":2}", 1_000L, EventRecord.RecordType.EVENT));
+
+        assertThat(HAUtils.calculateEventRecordSHA(first))
+                .isEqualTo(HAUtils.calculateEventRecordSHA(new EventRecordEntry(
+                        "event-1",
+                        0L,
+                        new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT))));
+
+        String manifest = HAUtils.calculateEventRecordsManifestSHA(List.of(first, second));
+        String reversedManifest = HAUtils.calculateEventRecordsManifestSHA(List.of(second, first));
+        String changedPayloadManifest = HAUtils.calculateEventRecordsManifestSHA(List.of(
+                new EventRecordEntry("event-1", 0L, new EventRecord("{\"i\":10}", 1_000L, EventRecord.RecordType.EVENT)),
+                second));
+
+        assertThat(manifest).isEqualTo(reversedManifest);
+        assertThat(manifest).isNotEqualTo(changedPayloadManifest);
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/HAEventRecordPersistenceTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/HAEventRecordPersistenceTest.java
@@ -1,0 +1,243 @@
+package org.drools.ansible.rulebook.integration.ha.tests;
+
+import java.util.List;
+
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
+import org.drools.ansible.rulebook.integration.ha.model.SessionState;
+import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
+import org.drools.ansible.rulebook.integration.ha.tests.state.HAStateManagerTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HAEventRecordPersistenceTest extends HAStateManagerTestBase {
+
+    private static final String HA_UUID = "event-record-persistence";
+    private static final String LEADER_ID = "event-record-leader";
+    private static final String RULE_SET_NAME = "event-record-ruleset";
+
+    private HAStateManager stateManager;
+
+    @BeforeEach
+    void setUp() {
+        stateManager = HAStateManagerFactory.create(TEST_DB_TYPE);
+        stateManager.initializeHA(HA_UUID, LEADER_ID, dbParams, dbHAConfig);
+        stateManager.enableLeader();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stateManager != null) {
+            stateManager.shutdown();
+        }
+        cleanupDatabase();
+    }
+
+    @Test
+    void persistsUpdatesDeletesAndLoadsEventRecordsInRecoveryOrder() {
+        EventRecordEntry second = new EventRecordEntry(
+                "event-2",
+                1L,
+                new EventRecord("{\"j\":2}", 1_000L, EventRecord.RecordType.EVENT));
+        EventRecordEntry first = new EventRecordEntry(
+                "event-1",
+                0L,
+                new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT));
+
+        stateManager.persistEventRecordChanges(RULE_SET_NAME, List.of(
+                EventRecordChange.upsert(second),
+                EventRecordChange.upsert(first)));
+
+        List<EventRecordEntry> loaded = stateManager.getPersistedEventRecords(RULE_SET_NAME);
+
+        assertThat(loaded).extracting(EventRecordEntry::getRecordIdentifier)
+                .containsExactly("event-1", "event-2");
+        assertThat(loaded).extracting(EventRecordEntry::getRecordSequence)
+                .containsExactly(0L, 1L);
+        assertThat(loaded.get(0).getRecord().getEventJson()).isEqualTo("{\"i\":1}");
+
+        EventRecordEntry updatedFirst = new EventRecordEntry(
+                "event-1",
+                0L,
+                new EventRecord("{\"i\":10}", 1_000L, EventRecord.RecordType.EVENT));
+
+        stateManager.persistEventRecordChanges(RULE_SET_NAME, List.of(
+                EventRecordChange.upsert(updatedFirst),
+                EventRecordChange.delete("event-2")));
+
+        loaded = stateManager.getPersistedEventRecords(RULE_SET_NAME);
+
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getRecordIdentifier()).isEqualTo("event-1");
+        assertThat(loaded.get(0).getRecordSequence()).isEqualTo(0L);
+        assertThat(loaded.get(0).getRecord().getEventJson()).isEqualTo("{\"i\":10}");
+    }
+
+    @Test
+    void rowAwareSessionPersistClearsLegacyBlobAndLoadsRowsForRecovery() {
+        EventRecord event1 = new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT);
+        EventRecord event2 = new EventRecord("{\"j\":2}", 2_000L, EventRecord.RecordType.EVENT);
+        EventRecordEntry entry1 = new EventRecordEntry("event-1", 0L, event1);
+        EventRecordEntry entry2 = new EventRecordEntry("event-2", 1L, event2);
+        List<EventRecordEntry> entries = List.of(entry1, entry2);
+
+        SessionState sessionState = new SessionState();
+        sessionState.setHaUuid(HA_UUID);
+        sessionState.setRuleSetName(RULE_SET_NAME);
+        sessionState.setLeaderId(LEADER_ID);
+        sessionState.setRulebookHash("rulebook-sha");
+        sessionState.setCreatedTime(100L);
+        sessionState.setPersistedTime(2_000L);
+        sessionState.setPartialEvents(List.of(event1, event2));
+        sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(entries));
+        sessionState.setCurrentStateSHA(HAUtils.calculateStateSHA(sessionState));
+
+        stateManager.loadOrCreateHAStats();
+        stateManager.persistSessionStateStatsEventRecordsAndMatchingEvents(sessionState,
+                                                                           entries.stream().map(EventRecordChange::upsert).toList(),
+                                                                           List.of());
+
+        String legacyBlob = TestUtils.queryRawColumn(dbParams,
+                                                     "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                             + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                                     HA_UUID);
+        String eventRecordRows = TestUtils.queryRawColumn(dbParams,
+                                                          "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                                          HA_UUID);
+
+        assertThat(legacyBlob).isEqualTo("__NULL__");
+        assertThat(eventRecordRows).isEqualTo("2");
+
+        SessionState loaded = stateManager.getPersistedSessionState(RULE_SET_NAME);
+
+        assertThat(loaded.getPartialEvents()).hasSize(2);
+        assertThat(loaded.getPartialEvents()).extracting(EventRecord::getEventJson)
+                .containsExactly("{\"i\":1}", "{\"j\":2}");
+        assertThat(loaded.getEventRecordsManifestSHA()).isEqualTo(HAUtils.calculateEventRecordsManifestSHA(entries));
+        assertThat(stateManager.verifySessionState(loaded)).isTrue();
+
+        stateManager.persistSessionState(loaded);
+
+        String legacyBlobAfterGenericUpsert = TestUtils.queryRawColumn(dbParams,
+                                                                       "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                                               + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                                                       HA_UUID);
+        assertThat(legacyBlobAfterGenericUpsert).isEqualTo("__NULL__");
+    }
+
+    @Test
+    void rowLoadFailsFastWhenEventRecordShaDoesNotMatchPayload() {
+        EventRecordEntry tamperedShaEntry = new EventRecordEntry(
+                "event-1",
+                0L,
+                new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT),
+                "not-the-row-sha");
+
+        stateManager.persistEventRecordChanges(RULE_SET_NAME, List.of(EventRecordChange.upsert(tamperedShaEntry)));
+
+        assertThatThrownBy(() -> stateManager.getPersistedEventRecords(RULE_SET_NAME))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("EventRecord SHA mismatch");
+    }
+
+    @Test
+    void sessionVerificationFailsFastWhenEventRecordManifestNoLongerMatchesSessionSha() {
+        EventRecord event1 = new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT);
+        EventRecordEntry entry1 = new EventRecordEntry("event-1", 0L, event1);
+
+        SessionState sessionState = new SessionState();
+        sessionState.setHaUuid(HA_UUID);
+        sessionState.setRuleSetName(RULE_SET_NAME);
+        sessionState.setLeaderId(LEADER_ID);
+        sessionState.setRulebookHash("rulebook-sha");
+        sessionState.setCreatedTime(100L);
+        sessionState.setPersistedTime(1_000L);
+        sessionState.setPartialEvents(List.of(event1));
+        sessionState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(List.of(entry1)));
+        sessionState.setCurrentStateSHA(HAUtils.calculateStateSHA(sessionState));
+
+        stateManager.loadOrCreateHAStats();
+        stateManager.persistSessionStateStatsEventRecordsAndMatchingEvents(sessionState,
+                                                                           List.of(EventRecordChange.upsert(entry1)),
+                                                                           List.of());
+
+        EventRecord updatedEvent = new EventRecord("{\"i\":10}", 1_000L, EventRecord.RecordType.EVENT);
+        EventRecordEntry updatedEntry = new EventRecordEntry("event-1", 0L, updatedEvent);
+        stateManager.persistEventRecordChanges(RULE_SET_NAME, List.of(EventRecordChange.upsert(updatedEntry)));
+
+        SessionState loaded = stateManager.getPersistedSessionState(RULE_SET_NAME);
+
+        assertThat(loaded.getPartialEvents()).extracting(EventRecord::getEventJson).containsExactly("{\"i\":10}");
+        assertThatThrownBy(() -> stateManager.verifySessionState(loaded))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SessionState integrity check failed");
+    }
+
+    @Test
+    void legacyBlobBackedStateMigratesToRowsOnNextRowAwarePersist() {
+        EventRecord event1 = new EventRecord("{\"i\":1}", 1_000L, EventRecord.RecordType.EVENT);
+        EventRecord event2 = new EventRecord("{\"j\":2}", 2_000L, EventRecord.RecordType.EVENT);
+
+        SessionState legacyState = new SessionState();
+        legacyState.setHaUuid(HA_UUID);
+        legacyState.setRuleSetName(RULE_SET_NAME);
+        legacyState.setLeaderId(LEADER_ID);
+        legacyState.setRulebookHash("rulebook-sha");
+        legacyState.setCreatedTime(100L);
+        legacyState.setPersistedTime(2_000L);
+        legacyState.setPartialEvents(List.of(event1, event2));
+        legacyState.setEventRecordsManifestSHA(null);
+        legacyState.setCurrentStateSHA(HAUtils.calculateStateSHA(legacyState));
+
+        stateManager.persistSessionState(legacyState);
+
+        String legacyBlobBeforeMigration = TestUtils.queryRawColumn(dbParams,
+                                                                    "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                                            + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                                                    HA_UUID);
+        String rowsBeforeMigration = TestUtils.queryRawColumn(dbParams,
+                                                              "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                                              HA_UUID);
+        assertThat(legacyBlobBeforeMigration).isNotEqualTo("__NULL__");
+        assertThat(rowsBeforeMigration).isEqualTo("0");
+
+        SessionState loadedLegacyState = stateManager.getPersistedSessionState(RULE_SET_NAME);
+        assertThat(loadedLegacyState.getEventRecordsManifestSHA()).isNull();
+        assertThat(loadedLegacyState.getPartialEvents()).hasSize(2);
+        assertThat(stateManager.verifySessionState(loadedLegacyState)).isTrue();
+
+        EventRecordEntry entry1 = new EventRecordEntry("event-1", 0L, event1);
+        EventRecordEntry entry2 = new EventRecordEntry("event-2", 1L, event2);
+        List<EventRecordEntry> entries = List.of(entry1, entry2);
+        loadedLegacyState.setEventRecordsManifestSHA(HAUtils.calculateEventRecordsManifestSHA(entries));
+        loadedLegacyState.setCurrentStateSHA(HAUtils.calculateStateSHA(loadedLegacyState));
+
+        stateManager.persistSessionStateEventRecordsAndMatchingEvents(loadedLegacyState,
+                                                                      entries.stream().map(EventRecordChange::upsert).toList(),
+                                                                      List.of());
+
+        String legacyBlobAfterMigration = TestUtils.queryRawColumn(dbParams,
+                                                                   "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                                           + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                                                   HA_UUID);
+        String rowsAfterMigration = TestUtils.queryRawColumn(dbParams,
+                                                             "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                                             HA_UUID);
+        assertThat(legacyBlobAfterMigration).isEqualTo("__NULL__");
+        assertThat(rowsAfterMigration).isEqualTo("2");
+
+        SessionState migratedState = stateManager.getPersistedSessionState(RULE_SET_NAME);
+        assertThat(migratedState.getEventRecordsManifestSHA()).isEqualTo(HAUtils.calculateEventRecordsManifestSHA(entries));
+        assertThat(migratedState.getPartialEvents()).extracting(EventRecord::getEventJson)
+                .containsExactly("{\"i\":1}", "{\"j\":2}");
+        assertThat(stateManager.verifySessionState(migratedState)).isTrue();
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationDifferentHaUuidCoexistenceTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationDifferentHaUuidCoexistenceTest.java
@@ -1,0 +1,311 @@
+package org.drools.ansible.rulebook.integration.ha.tests.integration.basic;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.drools.ansible.rulebook.integration.api.RuleConfigurationOption;
+import org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine;
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.SessionState;
+import org.drools.ansible.rulebook.integration.ha.tests.integration.HAIntegrationTestBase.AsyncConsumer;
+import org.drools.ansible.rulebook.integration.ha.tests.support.AbstractHATestBase;
+import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValueAsListOfMapOfStringAndObject;
+import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.toJson;
+import static org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils.createEvent;
+
+class HAIntegrationDifferentHaUuidCoexistenceTest extends AbstractHATestBase {
+
+    private static final String OLD_HA_UUID = "integration-old-ha";
+    private static final String NEW_HA_UUID = "integration-new-ha";
+    private static final String OLD_WORKER_NAME = "worker-old";
+    private static final String NEW_WORKER_NAME = "worker-new";
+    private static final String OLD_RULE_SET_NAME = "Legacy Coexistence Ruleset";
+    private static final String NEW_RULE_SET_NAME = "New Coexistence Ruleset";
+
+    private static final String OLD_RULE_SET = """
+            {
+                "name": "Legacy Coexistence Ruleset",
+                "rules": [
+                    {"Rule": {
+                        "name": "legacy_temperature_alert",
+                        "condition": {
+                            "AllCondition": [
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "i"
+                                        },
+                                        "rhs": {
+                                            "Integer": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "j"
+                                        },
+                                        "rhs": {
+                                            "Integer": 2
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "run_playbook": [
+                                {
+                                    "name": "send_alert.yml"
+                                }
+                            ]
+                        }
+                    }}
+                ]
+            }
+            """;
+
+    private static final String NEW_RULE_SET = """
+            {
+                "name": "New Coexistence Ruleset",
+                "rules": [
+                    {"Rule": {
+                        "name": "new_temperature_alert",
+                        "condition": {
+                            "AllCondition": [
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "i"
+                                        },
+                                        "rhs": {
+                                            "Integer": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "j"
+                                        },
+                                        "rhs": {
+                                            "Integer": 2
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "run_playbook": [
+                                {
+                                    "name": "send_alert.yml"
+                                }
+                            ]
+                        }
+                    }}
+                ]
+            }
+            """;
+
+    static {
+        if (USE_POSTGRES) {
+            initializePostgres("eda_ha_test", "HA different-ha_uuid coexistence integration tests");
+        } else {
+            initializeH2();
+        }
+    }
+
+    private AstRulesEngine rulesEngine;
+    private AsyncConsumer consumer;
+    private long sessionId;
+
+    @AfterEach
+    void tearDown() {
+        if (consumer != null) {
+            consumer.stop();
+        }
+        if (rulesEngine != null) {
+            rulesEngine.dispose(sessionId);
+            rulesEngine.close();
+        }
+        cleanupDatabase();
+    }
+
+    @Test
+    void newHaUuidRowBackedStateDoesNotTouchLegacyBlobStateOwnedByDifferentHaUuid() throws Exception {
+        long now = System.currentTimeMillis();
+
+        EventRecord oldRetainedEvent = new EventRecord("{\"meta\":{\"uuid\":\"old-legacy-event-1\"},\"i\":1}",
+                                                       now,
+                                                       EventRecord.RecordType.EVENT);
+        SessionState oldLegacyState = new SessionState();
+        oldLegacyState.setHaUuid(OLD_HA_UUID);
+        oldLegacyState.setRuleSetName(OLD_RULE_SET_NAME);
+        oldLegacyState.setRulebookHash(HAUtils.sha256(OLD_RULE_SET));
+        oldLegacyState.setPartialEvents(List.of(oldRetainedEvent));
+        oldLegacyState.setProcessedEventIds(List.of());
+        oldLegacyState.setCreatedTime(now);
+        oldLegacyState.setPersistedTime(now);
+        oldLegacyState.setLeaderId(OLD_WORKER_NAME);
+        oldLegacyState.setCurrentStateSHA(HAUtils.calculateStateSHA(oldLegacyState));
+
+        createLegacySchemaWithoutEventRecordTable();
+        insertLegacySessionState(oldLegacyState);
+
+        rulesEngine = new AstRulesEngine();
+        consumer = new AsyncConsumer("different-ha-uuid-consumer");
+        consumer.startConsuming(rulesEngine.port());
+
+        rulesEngine.initializeHA(NEW_HA_UUID, NEW_WORKER_NAME, dbParamsJson, dbHAConfigJson);
+
+        assertThat(eventRecordTableExists()).isTrue();
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            OLD_HA_UUID)).isNotEqualTo("__NULL__");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            OLD_HA_UUID)).isEqualTo("0");
+
+        sessionId = rulesEngine.createRuleset(NEW_RULE_SET, RuleConfigurationOption.FULLY_MANUAL_PSEUDOCLOCK);
+        rulesEngine.enableLeader();
+
+        String result = rulesEngine.assertEvent(sessionId, createEvent("{\"i\":1}"));
+        assertThat(readValueAsListOfMapOfStringAndObject(result)).isEmpty();
+
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            OLD_HA_UUID)).isNotEqualTo("__NULL__");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            OLD_HA_UUID)).isEqualTo("0");
+
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            NEW_HA_UUID)).isEqualTo("__NULL__");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            NEW_HA_UUID)).isEqualTo("1");
+
+        HAStateManager oldManager = HAStateManagerFactory.create(TEST_DB_TYPE);
+        try {
+            oldManager.initializeHA(OLD_HA_UUID, "FOR_ASSERTION_OLD", dbParams, dbHAConfig);
+            SessionState oldPersistedState = oldManager.getPersistedSessionState(OLD_RULE_SET_NAME);
+            assertThat(oldPersistedState.getEventRecordsManifestSHA()).isNull();
+            assertThat(oldPersistedState.getPartialEvents()).hasSize(1);
+            assertThat(oldPersistedState.getPartialEvents().get(0).getEventJson()).contains("\"old-legacy-event-1\"");
+            assertThat(oldManager.verifySessionState(oldPersistedState)).isTrue();
+        } finally {
+            oldManager.shutdown();
+        }
+
+        HAStateManager newManager = HAStateManagerFactory.create(TEST_DB_TYPE);
+        try {
+            newManager.initializeHA(NEW_HA_UUID, "FOR_ASSERTION_NEW", dbParams, dbHAConfig);
+            SessionState newPersistedState = newManager.getPersistedSessionState(NEW_RULE_SET_NAME);
+            assertThat(newPersistedState.getEventRecordsManifestSHA()).isNotNull();
+            assertThat(newPersistedState.getPartialEvents()).hasSize(1);
+            assertThat(newPersistedState.getPartialEvents().get(0).getEventJson()).contains("\"i\":1");
+            assertThat(newManager.verifySessionState(newPersistedState)).isTrue();
+        } finally {
+            newManager.shutdown();
+        }
+    }
+
+    private void createLegacySchemaWithoutEventRecordTable() throws SQLException {
+        try (Connection conn = openConnection();
+             PreparedStatement psSessionState = conn.prepareStatement(legacySessionStateDdl())) {
+            psSessionState.execute();
+        }
+    }
+
+    private void insertLegacySessionState(SessionState legacyState) throws SQLException {
+        String sql = "INSERT INTO drools_ansible_session_state "
+                + "(ha_uuid, rule_set_name, rulebook_hash, partial_matching_events, processed_event_ids, persisted_time, current_state_sha, created_time, leader_id) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (Connection conn = openConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, legacyState.getHaUuid());
+            ps.setString(2, legacyState.getRuleSetName());
+            ps.setString(3, legacyState.getRulebookHash());
+            ps.setString(4, toJson(legacyState.getPartialEvents()));
+            ps.setString(5, toJson(legacyState.getProcessedEventIds()));
+            ps.setTimestamp(6, new Timestamp(legacyState.getPersistedTime()));
+            ps.setString(7, legacyState.getCurrentStateSHA());
+            ps.setTimestamp(8, new Timestamp(legacyState.getCreatedTime()));
+            ps.setString(9, legacyState.getLeaderId());
+            ps.executeUpdate();
+        }
+    }
+
+    private boolean eventRecordTableExists() throws SQLException {
+        String sql = USE_POSTGRES
+                ? "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'drools_ansible_event_record')"
+                : "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'DROOLS_ANSIBLE_EVENT_RECORD'";
+        try (Connection conn = openConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return USE_POSTGRES ? rs.getBoolean(1) : rs.getInt(1) > 0;
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        if (USE_POSTGRES) {
+            String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s",
+                                           dbParams.get("host"),
+                                           dbParams.get("port"),
+                                           dbParams.get("database"));
+            return DriverManager.getConnection(jdbcUrl,
+                                               (String) dbParams.get("user"),
+                                               (String) dbParams.get("password"));
+        }
+        String jdbcUrl = "jdbc:h2:file:" + dbParams.get("db_file_path") + ";MODE=PostgreSQL";
+        return DriverManager.getConnection(jdbcUrl, "sa", "");
+    }
+
+    private String legacySessionStateDdl() {
+        if (USE_POSTGRES) {
+            return "CREATE TABLE drools_ansible_session_state ("
+                    + "id BIGSERIAL PRIMARY KEY, "
+                    + "ha_uuid VARCHAR(255) NOT NULL, "
+                    + "rule_set_name VARCHAR(255) NOT NULL, "
+                    + "rulebook_hash VARCHAR(64) NOT NULL, "
+                    + "partial_matching_events TEXT, "
+                    + "processed_event_ids TEXT, "
+                    + "persisted_time TIMESTAMP, "
+                    + "current_state_sha VARCHAR(64) NOT NULL, "
+                    + "created_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                    + "leader_id VARCHAR(255), "
+                    + "UNIQUE(ha_uuid, rule_set_name)"
+                    + ")";
+        }
+        return "CREATE TABLE drools_ansible_session_state ("
+                + "id BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, "
+                + "ha_uuid VARCHAR(255) NOT NULL, "
+                + "rule_set_name VARCHAR(255) NOT NULL, "
+                + "rulebook_hash VARCHAR(64) NOT NULL, "
+                + "partial_matching_events CLOB, "
+                + "processed_event_ids CLOB, "
+                + "persisted_time TIMESTAMP, "
+                + "current_state_sha VARCHAR(64) NOT NULL, "
+                + "created_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                + "leader_id VARCHAR(255), "
+                + "UNIQUE(ha_uuid, rule_set_name)"
+                + ")";
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationLegacyPartialEventsMigrationTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationLegacyPartialEventsMigrationTest.java
@@ -1,0 +1,259 @@
+package org.drools.ansible.rulebook.integration.ha.tests.integration.basic;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.drools.ansible.rulebook.integration.api.RuleConfigurationOption;
+import org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine;
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
+import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.SessionState;
+import org.drools.ansible.rulebook.integration.ha.tests.integration.HAIntegrationTestBase.AsyncConsumer;
+import org.drools.ansible.rulebook.integration.ha.tests.support.AbstractHATestBase;
+import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValueAsListOfMapOfStringAndObject;
+import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.toJson;
+import static org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils.createEvent;
+
+class HAIntegrationLegacyPartialEventsMigrationTest extends AbstractHATestBase {
+
+    private static final String HA_UUID = "integration-legacy-migration";
+    private static final String WORKER_NAME = "worker-legacy";
+    private static final String RULE_SET_NAME = "Legacy Migration Ruleset";
+    private static final String RULE_SET = """
+            {
+                "name": "Legacy Migration Ruleset",
+                "rules": [
+                    {"Rule": {
+                        "name": "temperature_alert",
+                        "condition": {
+                            "AllCondition": [
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "i"
+                                        },
+                                        "rhs": {
+                                            "Integer": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "EqualsExpression": {
+                                        "lhs": {
+                                            "Event": "j"
+                                        },
+                                        "rhs": {
+                                            "Integer": 2
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "run_playbook": [
+                                {
+                                    "name": "send_alert.yml",
+                                    "extra_vars": {
+                                        "message": "High temperature detected"
+                                    }
+                                }
+                            ]
+                        }
+                    }}
+                ]
+            }
+            """;
+
+    static {
+        if (USE_POSTGRES) {
+            initializePostgres("eda_ha_test", "HA legacy migration integration tests");
+        } else {
+            initializeH2();
+        }
+    }
+
+    private AstRulesEngine rulesEngine;
+    private AsyncConsumer consumer;
+    private long sessionId;
+
+    @AfterEach
+    void tearDown() {
+        if (consumer != null) {
+            consumer.stop();
+        }
+        if (rulesEngine != null) {
+            rulesEngine.dispose(sessionId);
+            rulesEngine.close();
+        }
+        cleanupDatabase();
+    }
+
+    @Test
+    void legacyPartialMatchingEventsMigratesToEventRecordRowsAfterStartupAndNextEvent() throws Exception {
+        long now = System.currentTimeMillis();
+
+        EventRecord retainedEvent = new EventRecord("{\"meta\":{\"uuid\":\"legacy-event-1\"},\"i\":1}",
+                                                    now,
+                                                    EventRecord.RecordType.EVENT);
+        SessionState legacyState = new SessionState();
+        legacyState.setHaUuid(HA_UUID);
+        legacyState.setRuleSetName(RULE_SET_NAME);
+        legacyState.setRulebookHash(HAUtils.sha256(RULE_SET));
+        legacyState.setPartialEvents(List.of(retainedEvent));
+        legacyState.setProcessedEventIds(List.of());
+        legacyState.setCreatedTime(now);
+        legacyState.setPersistedTime(now);
+        legacyState.setLeaderId(WORKER_NAME);
+        legacyState.setCurrentStateSHA(HAUtils.calculateStateSHA(legacyState));
+
+        createLegacySchemaWithoutEventRecordTable();
+        insertLegacySessionState(legacyState);
+
+        assertThat(eventRecordTableExists()).isFalse();
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            HA_UUID)).isNotEqualTo("__NULL__");
+
+        rulesEngine = new AstRulesEngine();
+        consumer = new AsyncConsumer("legacy-migration-consumer");
+        consumer.startConsuming(rulesEngine.port());
+
+        rulesEngine.initializeHA(HA_UUID, WORKER_NAME, dbParamsJson, dbHAConfigJson);
+
+        assertThat(eventRecordTableExists()).isTrue();
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            HA_UUID)).isNotEqualTo("__NULL__");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            HA_UUID)).isEqualTo("0");
+
+        sessionId = rulesEngine.createRuleset(RULE_SET, RuleConfigurationOption.FULLY_MANUAL_PSEUDOCLOCK);
+        rulesEngine.enableLeader();
+
+        String result = rulesEngine.assertEvent(sessionId, createEvent("{\"k\":3}"));
+        assertThat(readValueAsListOfMapOfStringAndObject(result)).isEmpty();
+
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                    + "FROM drools_ansible_session_state WHERE ha_uuid = ?",
+                                            HA_UUID)).isEqualTo("__NULL__");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            HA_UUID)).isEqualTo("1");
+        assertThat(TestUtils.queryRawColumn(dbParams,
+                                            "SELECT event_json FROM drools_ansible_event_record WHERE ha_uuid = ?",
+                                            HA_UUID)).contains("\"legacy-event-1\"")
+                                                    .contains("\"i\":1");
+
+        HAStateManager manager = HAStateManagerFactory.create(TEST_DB_TYPE);
+        try {
+            manager.initializeHA(HA_UUID, "FOR_ASSERTION", dbParams, dbHAConfig);
+            SessionState persistedState = manager.getPersistedSessionState(RULE_SET_NAME);
+            assertThat(persistedState.getEventRecordsManifestSHA()).isNotNull();
+            assertThat(persistedState.getPartialEvents()).hasSize(1);
+            assertThat(persistedState.getPartialEvents().get(0).getEventJson()).contains("\"legacy-event-1\"")
+                                                                                 .contains("\"i\":1");
+            assertThat(manager.verifySessionState(persistedState)).isTrue();
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private void createLegacySchemaWithoutEventRecordTable() throws SQLException {
+        try (Connection conn = openConnection();
+             PreparedStatement psSessionState = conn.prepareStatement(legacySessionStateDdl())) {
+            psSessionState.execute();
+        }
+    }
+
+    private void insertLegacySessionState(SessionState legacyState) throws SQLException {
+        String sql = "INSERT INTO drools_ansible_session_state "
+                + "(ha_uuid, rule_set_name, rulebook_hash, partial_matching_events, processed_event_ids, persisted_time, current_state_sha, created_time, leader_id) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (Connection conn = openConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, legacyState.getHaUuid());
+            ps.setString(2, legacyState.getRuleSetName());
+            ps.setString(3, legacyState.getRulebookHash());
+            ps.setString(4, toJson(legacyState.getPartialEvents()));
+            ps.setString(5, toJson(legacyState.getProcessedEventIds()));
+            ps.setTimestamp(6, new Timestamp(legacyState.getPersistedTime()));
+            ps.setString(7, legacyState.getCurrentStateSHA());
+            ps.setTimestamp(8, new Timestamp(legacyState.getCreatedTime()));
+            ps.setString(9, legacyState.getLeaderId());
+            ps.executeUpdate();
+        }
+    }
+
+    private boolean eventRecordTableExists() throws SQLException {
+        String sql = USE_POSTGRES
+                ? "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'drools_ansible_event_record')"
+                : "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'DROOLS_ANSIBLE_EVENT_RECORD'";
+        try (Connection conn = openConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return USE_POSTGRES ? rs.getBoolean(1) : rs.getInt(1) > 0;
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        if (USE_POSTGRES) {
+            String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s",
+                                           dbParams.get("host"),
+                                           dbParams.get("port"),
+                                           dbParams.get("database"));
+            return DriverManager.getConnection(jdbcUrl,
+                                               (String) dbParams.get("user"),
+                                               (String) dbParams.get("password"));
+        }
+        String jdbcUrl = "jdbc:h2:file:" + dbParams.get("db_file_path") + ";MODE=PostgreSQL";
+        return DriverManager.getConnection(jdbcUrl, "sa", "");
+    }
+
+    private String legacySessionStateDdl() {
+        if (USE_POSTGRES) {
+            return "CREATE TABLE drools_ansible_session_state ("
+                    + "id BIGSERIAL PRIMARY KEY, "
+                    + "ha_uuid VARCHAR(255) NOT NULL, "
+                    + "rule_set_name VARCHAR(255) NOT NULL, "
+                    + "rulebook_hash VARCHAR(64) NOT NULL, "
+                    + "partial_matching_events TEXT, "
+                    + "processed_event_ids TEXT, "
+                    + "persisted_time TIMESTAMP, "
+                    + "current_state_sha VARCHAR(64) NOT NULL, "
+                    + "created_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                    + "leader_id VARCHAR(255), "
+                    + "UNIQUE(ha_uuid, rule_set_name)"
+                    + ")";
+        }
+        return "CREATE TABLE drools_ansible_session_state ("
+                + "id BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, "
+                + "ha_uuid VARCHAR(255) NOT NULL, "
+                + "rule_set_name VARCHAR(255) NOT NULL, "
+                + "rulebook_hash VARCHAR(64) NOT NULL, "
+                + "partial_matching_events CLOB, "
+                + "processed_event_ids CLOB, "
+                + "persisted_time TIMESTAMP, "
+                + "current_state_sha VARCHAR(64) NOT NULL, "
+                + "created_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                + "leader_id VARCHAR(255), "
+                + "UNIQUE(ha_uuid, rule_set_name)"
+                + ")";
+    }
+}

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationMultiConditionTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/basic/HAIntegrationMultiConditionTest.java
@@ -7,6 +7,8 @@ import org.drools.ansible.rulebook.integration.ha.tests.integration.HAIntegratio
 import java.util.List;
 import java.util.Map;
 
+import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
+import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +83,30 @@ class HAIntegrationMultiConditionTest extends HAIntegrationTestBase {
 
         // Should be empty since rule requires both i=1 AND j=2
         assertThat(readValueAsListOfMapOfStringAndObject(result1)).isEmpty();
+
+        String eventRecordRows = TestUtils.queryRawColumn(dbParams,
+                                                          "SELECT COUNT(*) FROM drools_ansible_event_record "
+                                                                  + "WHERE ha_uuid = ? AND rule_set_name = 'Multi Condition Ruleset'",
+                                                          HA_UUID);
+        assertThat(eventRecordRows).isEqualTo("1");
+
+        String legacyPartialEventsBlob = TestUtils.queryRawColumn(dbParams,
+                                                                  "SELECT COALESCE(partial_matching_events, '__NULL__') "
+                                                                          + "FROM drools_ansible_session_state "
+                                                                          + "WHERE ha_uuid = ? AND rule_set_name = 'Multi Condition Ruleset'",
+                                                                  HA_UUID);
+        assertThat(legacyPartialEventsBlob).isEqualTo("__NULL__");
+
+        HAStateManager haManagerForAssertion = createHAStateManagerForAssertion();
+        try {
+            SessionState persistedState = haManagerForAssertion.getPersistedSessionState(getRuleSetNameValue());
+            assertThat(persistedState.getPartialEvents()).hasSize(1);
+            assertThat(persistedState.getPartialEvents().get(0).getEventJson()).contains("\"i\":1");
+            assertThat(persistedState.getEventRecordsManifestSHA()).isNotNull();
+            assertThat(haManagerForAssertion.verifySessionState(persistedState)).isTrue();
+        } finally {
+            haManagerForAssertion.shutdown();
+        }
 
         String haStatsJson = rulesEngine1.getHAStats();
         Map<String, Object> haStats = readValueAsMapOfStringAndObject(haStatsJson);

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/encryption/HAIntegrationEncryptionTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/encryption/HAIntegrationEncryptionTest.java
@@ -84,6 +84,37 @@ class HAIntegrationEncryptionTest extends AbstractHATestBase {
             }
             """;
 
+    private static final String PARTIAL_EVENT_RULE_SET = """
+            {
+                "name": "Encryption Partial Event Ruleset",
+                "sources": {"EventSource": "test"},
+                "rules": [
+                    {"Rule": {
+                        "name": "temp_and_humidity_alert",
+                        "condition": {
+                            "AllCondition": [
+                                {
+                                    "GreaterThanExpression": {
+                                        "lhs": {"Event": "temperature"},
+                                        "rhs": {"Integer": 30}
+                                    }
+                                },
+                                {
+                                    "GreaterThanExpression": {
+                                        "lhs": {"Event": "humidity"},
+                                        "rhs": {"Integer": 70}
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "run_playbook": [{"name": "alert.yml"}]
+                        }
+                    }}
+                ]
+            }
+            """;
+
     private AstRulesEngine rulesEngine1;
     private AstRulesEngine rulesEngine2;
     private long sessionId1;
@@ -151,7 +182,11 @@ class HAIntegrationEncryptionTest extends AbstractHATestBase {
 
         String rawPartialEvents = TestUtils.queryRawColumn(dbParams,
                 "SELECT partial_matching_events FROM drools_ansible_session_state WHERE ha_uuid = ?", HA_UUID);
-        assertThat(rawPartialEvents).startsWith("$ENCRYPTED$");
+        assertThat(rawPartialEvents).isNull();
+
+        String eventRecordRowCount = TestUtils.queryRawColumn(dbParams,
+                "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?", HA_UUID);
+        assertThat(eventRecordRowCount).isEqualTo("0");
 
         // Verify matching event is persisted and readable with encryption
         HAStateManager assertionManager = createEncryptedStateManager();
@@ -196,6 +231,48 @@ class HAIntegrationEncryptionTest extends AbstractHATestBase {
         List<Map<String, Object>> resultList = (List<Map<String, Object>>) asyncResultMap.get("result");
         assertThat(resultList).isNotEmpty();
         assertThat(resultList.get(0)).containsEntry("matching_uuid", meUuid);
+    }
+
+    @Test
+    void encryptedEventRecordRowPersistAndRecovery() {
+        AstRulesEngine partialEngine = new AstRulesEngine();
+        HAIntegrationTestBase.AsyncConsumer partialConsumer = new HAIntegrationTestBase.AsyncConsumer("consumer-partial");
+        partialConsumer.startConsuming(partialEngine.port());
+
+        try {
+            partialEngine.initializeHA(HA_UUID, "worker-partial", dbParamsJson, encryptedConfigJson);
+            long partialSessionId = partialEngine.createRuleset(PARTIAL_EVENT_RULE_SET, RuleConfigurationOption.FULLY_MANUAL_PSEUDOCLOCK);
+            partialEngine.enableLeader();
+
+            String result = partialEngine.assertEvent(partialSessionId, createEvent("{\"temperature\": 45, \"host\": \"server-01\"}"));
+            List<Map<String, Object>> matchList = readValueAsListOfMapOfStringAndObject(result);
+            assertThat(matchList).isEmpty();
+
+            String rawEventJson = TestUtils.queryRawColumn(dbParams,
+                    "SELECT event_json FROM drools_ansible_event_record WHERE ha_uuid = ?", HA_UUID);
+            assertThat(rawEventJson).startsWith("$ENCRYPTED$");
+            assertThat(rawEventJson).doesNotContain("server-01");
+            assertThat(rawEventJson).doesNotContain("temperature");
+
+            HAStateManager assertionManager = createEncryptedStateManager();
+            try {
+                var entries = assertionManager.getPersistedEventRecords("Encryption Partial Event Ruleset");
+                assertThat(entries).hasSize(1);
+                assertThat(entries.get(0).getRecord().getEventJson()).contains("\"temperature\": 45");
+                assertThat(entries.get(0).getRecord().getEventJson()).contains("\"host\": \"server-01\"");
+            } finally {
+                assertionManager.shutdown();
+            }
+
+            partialEngine.disableLeader();
+            partialEngine.dispose(partialSessionId);
+            partialEngine.close();
+        } finally {
+            partialConsumer.stop();
+            if (partialEngine != null) {
+                partialEngine.close();
+            }
+        }
     }
 
     @Test
@@ -312,16 +389,15 @@ class HAIntegrationEncryptionTest extends AbstractHATestBase {
         String nonMatchingEvent = createEvent("{\"temperature\": 10}");
         rulesEngine1.assertEvent(sessionId1, nonMatchingEvent);
 
-        // Verify session state is now re-encrypted with the new primary key:
-        // query the latest version from DB and decrypt directly with only the rotated key (no secondary)
+        // This ruleset has no retained partial events, so the session row should
+        // stay on the row-backed shape without reviving the legacy blob.
         String reEncryptedData = TestUtils.queryRawColumn(dbParams,
                 "SELECT partial_matching_events FROM drools_ansible_session_state WHERE ha_uuid = ?", HA_UUID);
-        assertThat(reEncryptedData).startsWith("$ENCRYPTED$");
+        assertThat(reEncryptedData).isNull();
 
-        HAEncryption rotatedOnlyEncryption = new HAEncryption(NEW_ENCRYPTION_KEY, null);
-        HAEncryption.DecryptResult decryptResult = rotatedOnlyEncryption.decrypt(reEncryptedData);
-        assertThat(decryptResult.usedSecondaryKey()).isFalse();
-        assertThat(decryptResult.plaintext()).isNotNull();
+        String eventRecordRowCount = TestUtils.queryRawColumn(dbParams,
+                "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?", HA_UUID);
+        assertThat(eventRecordRowCount).isEqualTo("0");
     }
 
     @Test

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/memory/HAIntegrationMemoryLeakTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/memory/HAIntegrationMemoryLeakTest.java
@@ -9,6 +9,7 @@ import org.drools.ansible.rulebook.integration.api.RuleConfigurationOption;
 import org.drools.ansible.rulebook.integration.api.io.JsonMapper;
 import org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine;
 import org.drools.ansible.rulebook.integration.ha.tests.support.AbstractHATestBase;
+import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,7 +113,7 @@ class HAIntegrationMemoryLeakTest extends AbstractHATestBase {
         }
 
         // Allow some memory for the processing overhead (This is brittle threshold, can be adjusted when fail)
-        long acceptableMemoryOverhead = 50 * 1000 * 1024; // 50 MB
+        long acceptableMemoryOverhead = 65 * 1000 * 1024; // 65 MB
         System.gc();
         Map<String, Object> statsMap = JsonMapper.readValueAsMapOfStringAndObject(rulesEngine.sessionStats(sessionId));
         long baseLevelMemory = (Integer)statsMap.get("baseLevelMemory");
@@ -120,6 +121,10 @@ class HAIntegrationMemoryLeakTest extends AbstractHATestBase {
         System.out.println("baseLevelMemory = " + baseLevelMemory);
         System.out.println("usedMemory      = " + usedMemory);
         assertThat(usedMemory).isLessThan(baseLevelMemory + acceptableMemoryOverhead);
+
+        String eventRecordRowCount = TestUtils.queryRawColumn(dbParams,
+                                                              "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?", HA_UUID);
+        assertThat(eventRecordRowCount).isEqualTo("0");
     }
 
     @Test
@@ -132,8 +137,11 @@ class HAIntegrationMemoryLeakTest extends AbstractHATestBase {
             assertThat(matchList).isEmpty();
         }
 
+        List<String> partialEventIds = JsonMapper.readValue(rulesEngine.getPartialEventIds(sessionId), List.class);
+        assertThat(partialEventIds).isEmpty();
+
         // Allow some memory for the processing overhead
-        long acceptableMemoryOverhead = 50 * 1000 * 1024; // 50 MB (This is brittle threshold, can be adjusted when fail)
+        long acceptableMemoryOverhead = 65 * 1000 * 1024; // 65 MB (This is brittle threshold, can be adjusted when fail)
         System.gc();
         Map<String, Object> statsMap = JsonMapper.readValueAsMapOfStringAndObject(rulesEngine.sessionStats(sessionId));
         long baseLevelMemory = (Integer)statsMap.get("baseLevelMemory");
@@ -141,6 +149,10 @@ class HAIntegrationMemoryLeakTest extends AbstractHATestBase {
         System.out.println("baseLevelMemory = " + baseLevelMemory);
         System.out.println("usedMemory      = " + usedMemory);
         assertThat(usedMemory).isLessThan(baseLevelMemory + acceptableMemoryOverhead);
+
+        String eventRecordRowCount = TestUtils.queryRawColumn(dbParams,
+                "SELECT COUNT(*) FROM drools_ansible_event_record WHERE ha_uuid = ?", HA_UUID);
+        assertThat(eventRecordRowCount).isEqualTo("0");
     }
 
     private static String createLargeTriggerEvent(int sequence, int blobSize, boolean trigger) {

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/perf/HAIntegrationLargePartialMatchTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/integration/perf/HAIntegrationLargePartialMatchTest.java
@@ -101,7 +101,6 @@ class HAIntegrationLargePartialMatchTest extends AbstractHATestBase {
         cleanupDatabase();
     }
 
-    @Disabled("Just to check the response time")
     @Test
     void testLargePartialEventLastResponseTime() {
         long lastResponseNanos = 0L;
@@ -113,10 +112,33 @@ class HAIntegrationLargePartialMatchTest extends AbstractHATestBase {
             lastResponse = rulesEngine.assertEvent(sessionId, event);
             lastResponseNanos = System.nanoTime() - start;
         }
+        System.gc();
+        System.out.println("UsedMemory = " + (Runtime.getRuntime().totalMemory() -  Runtime.getRuntime().freeMemory()));
 
         double lastResponseMillis = lastResponseNanos / 1_000_000.0;
         System.out.printf("Large partial event test: count=%d payloadBytes=%d lastResponseMs=%.3f%n",
                 LARGE_PARTIAL_EVENT_COUNT, PARTIAL_EVENT_BLOB_SIZE, lastResponseMillis);
+        System.out.println("Large partial event test last response: " + lastResponse);
+    }
+
+    @Test
+    void testLargePartialEventLastResponseTimeWithExpiry() {
+        long lastResponseNanos = 0L;
+        String lastResponse = null;
+
+        for (int i = 0; i < LARGE_PARTIAL_EVENT_COUNT; i++) {
+            String event = createLargePartialEvent(i, PARTIAL_EVENT_BLOB_SIZE);
+            long start = System.nanoTime();
+            lastResponse = rulesEngine.assertEvent(sessionId, event);
+            lastResponseNanos = System.nanoTime() - start;
+            rulesEngine.advanceTime(sessionId, 1, "MINUTES"); // 60 * 2h = 120 events are retained before TTL
+        }
+        System.gc();
+        System.out.println("UsedMemory = " + (Runtime.getRuntime().totalMemory() -  Runtime.getRuntime().freeMemory()));
+
+        double lastResponseMillis = lastResponseNanos / 1_000_000.0;
+        System.out.printf("Large partial event test: count=%d payloadBytes=%d lastResponseMs=%.3f%n",
+                          LARGE_PARTIAL_EVENT_COUNT, PARTIAL_EVENT_BLOB_SIZE, lastResponseMillis);
         System.out.println("Large partial event test last response: " + lastResponse);
     }
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerEncryptionTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerEncryptionTest.java
@@ -15,6 +15,8 @@ import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
 import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
 import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
 import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.drools.ansible.rulebook.integration.ha.model.MatchingEvent;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.junit.jupiter.api.AfterEach;
@@ -127,6 +129,30 @@ class HAStateManagerEncryptionTest extends HAStateManagerTestBase {
         assertThat(loaded.get(0).getMeUuid()).isEqualTo(meUuid);
         assertThat(loaded.get(0).getEventData()).contains("temperature");
         assertThat(loaded.get(0).getEventData()).contains("server-01");
+    }
+
+    @Test
+    void persistAndLoadEventRecordRowWithEncryption() {
+        String key = generateBase64Key();
+        stateManager = createManager(configWithEncryption(key, null));
+
+        EventRecord eventRecord = new EventRecord("{\"temperature\": 35, \"host\": \"server-01\"}",
+                                                  System.currentTimeMillis(),
+                                                  EventRecord.RecordType.EVENT);
+        EventRecordEntry entry = new EventRecordEntry("event-1", 0L, eventRecord);
+
+        stateManager.persistEventRecordChanges(RULE_SET_NAME, List.of(EventRecordChange.upsert(entry)));
+
+        String rawEventJson = TestUtils.queryRawColumn(dbParams,
+                "SELECT event_json FROM drools_ansible_event_record WHERE ha_uuid = ?", haUuid);
+        assertThat(rawEventJson).startsWith("$ENCRYPTED$");
+        assertThat(rawEventJson).doesNotContain("server-01");
+        assertThat(rawEventJson).doesNotContain("temperature");
+
+        List<EventRecordEntry> loaded = stateManager.getPersistedEventRecords(RULE_SET_NAME);
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getRecord().getEventJson()).contains("\"temperature\": 35");
+        assertThat(loaded.get(0).getRecord().getEventJson()).contains("\"host\": \"server-01\"");
     }
 
     @Test

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/support/TestUtils.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/support/TestUtils.java
@@ -1,7 +1,5 @@
 package org.drools.ansible.rulebook.integration.ha.tests.support;
 
-import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
-
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;

--- a/drools-ansible-rulebook-integration-main/load_test_failover.sh
+++ b/drools-ansible-rulebook-integration-main/load_test_failover.sh
@@ -136,10 +136,20 @@ parse_metrics() {
   fi
 }
 
+pg_count() {
+  local table="$1"
+  docker exec "$PG_CONTAINER" psql -U failovertest -d failovertest -tAc "SELECT COUNT(*) FROM $table" 2>/dev/null || echo "ERR"
+}
+
+pg_blob_size() {
+  docker exec "$PG_CONTAINER" psql -U failovertest -d failovertest -tAc \
+    "SELECT COALESCE(MAX(length(partial_matching_events)), 0) FROM drools_ansible_session_state" 2>/dev/null || echo "ERR"
+}
+
 # 7) Header
 header=$(printf "=== Failover Recovery Load Test (size=%s) ===" "$size")
-table_header=$(printf "\n%-36s %-14s %14s %9s" "File" "Phase" "Memory(bytes)" "Time(ms)")
-separator=$(printf "%s" "$(head -c 75 < /dev/zero | tr '\0' '-')")
+table_header=$(printf "\n%-36s %-14s %14s %9s %10s %14s" "File" "Phase" "Memory(bytes)" "Time(ms)" "EVENT_REC" "BlobSize(B)")
+separator=$(printf "%s" "$(head -c 102 < /dev/zero | tr '\0' '-')")
 
 {
   echo "$header"
@@ -155,6 +165,8 @@ run_java "$test_file (node1-load)" "$test_file" \
   --ha-uuid "$HA_UUID"
 parse_metrics "$_run_stderr" "$test_file"
 load_mem="$_mem"; load_time="$_time"
+load_event_record_rows=$(pg_count "drools_ansible_event_record")
+load_blob_size=$(pg_blob_size)
 
 # 9) Phase 2: Failover recovery (Node2)
 echo "Phase 2: Failover recovery ($test_file)..."
@@ -164,6 +176,8 @@ run_java "$test_file (node2-recovery)" "$test_file" \
   --failover-recovery
 parse_metrics "$_run_stderr" "$test_file"
 recovery_mem="$_mem"; recovery_time="$_time"
+recovery_event_record_rows=$(pg_count "drools_ansible_event_record")
+recovery_blob_size=$(pg_blob_size)
 
 # 10) Calculate ratio
 ratio="N/A"
@@ -173,9 +187,9 @@ fi
 
 # 11) Print results
 {
-  printf "%-36s %-14s %14s %9s\n" "$test_file" "Load(PG)" "$load_mem" "$load_time"
-  printf "%-36s %-14s %14s %9s\n" "$test_file" "Recovery(PG)" "$recovery_mem" "$recovery_time"
-  printf "%-36s %-14s %14s %8s%%\n" "" "Ratio" "" "$ratio"
+  printf "%-36s %-14s %14s %9s %10s %14s\n" "$test_file" "Load(PG)" "$load_mem" "$load_time" "$load_event_record_rows" "$load_blob_size"
+  printf "%-36s %-14s %14s %9s %10s %14s\n" "$test_file" "Recovery(PG)" "$recovery_mem" "$recovery_time" "$recovery_event_record_rows" "$recovery_blob_size"
+  printf "%-36s %-14s %14s %8s%% %10s %14s\n" "" "Ratio" "" "$ratio" "" ""
   echo ""
 } | tee -a "$out"
 

--- a/drools-ansible-rulebook-integration-main/load_test_retention.sh
+++ b/drools-ansible-rulebook-integration-main/load_test_retention.sh
@@ -6,7 +6,7 @@
 # Uses failover_XX_events.json (2-condition join rule, only condition 1 satisfied).
 # All events stay in working memory as partial matches — never matched, never discarded.
 #
-# Runs 100, 500, 1k events in both noHA and HA(PG) modes.
+# Runs 100, 500, 1k, 5k, 10k events in both noHA and HA(PG) modes.
 # Reports memory and per-event memory estimate for each.
 # Requires Docker for PostgreSQL.
 
@@ -20,13 +20,15 @@ if [ ! -f "$JAR" ]; then
   exit 1
 fi
 
-SIZES=(100 500 1k)
-FILES=("failover_100_events.json" "failover_500_events.json" "failover_1k_events.json")
-COUNTS=(100 500 1000)
+SIZES=(100 500 1k 5k 10k)
+FILES=()
+COUNTS=(100 500 1000 5000 10000)
 
 OUT="result_retention.txt"
 LOG="out_retention.log"
 > "$LOG"
+
+TMP_INPUT_DIR=$(mktemp -d)
 
 # Docker PostgreSQL setup
 PG_CONTAINER=""
@@ -82,22 +84,57 @@ cleanup_postgres() {
     docker stop "$PG_CONTAINER" >/dev/null 2>&1 || true
     PG_CONTAINER=""
   fi
+  if [ -n "${TMP_INPUT_DIR:-}" ] && [ -d "$TMP_INPUT_DIR" ]; then
+    rm -rf "$TMP_INPUT_DIR"
+  fi
 }
 
 trap cleanup_postgres EXIT
 
 setup_postgres
 
-# Helper: run java, capture stderr for metrics
+generate_failover_input() {
+  local size="$1"
+  local count="$2"
+
+  case "$size" in
+    100|500|1k)
+      echo "failover_${size}_events.json"
+      return
+      ;;
+  esac
+
+  local template="src/main/resources/failover_1k_events.json"
+  local generated="$TMP_INPUT_DIR/failover_${size}_events.json"
+
+  sed \
+    -e "s/\"name\": \"failover 1k events\"/\"name\": \"failover ${count} events\"/" \
+    -e '0,/"repeat_count": 1000/s//"repeat_count": '"$count"'/' \
+    "$template" > "$generated"
+
+  echo "$generated"
+}
+
+for idx in "${!SIZES[@]}"; do
+  FILES+=("$(generate_failover_input "${SIZES[$idx]}" "${COUNTS[$idx]}")")
+done
+
+# Helper: run java, capture stdout/stderr for metrics
 run_java() {
   local label="$1"; shift
+  local tmpstdout
   local tmpstderr
+  tmpstdout=$(mktemp)
   tmpstderr=$(mktemp)
   echo "=== $label ===" >> "$LOG"
   java -Xmx1g -Dorg.slf4j.simpleLogger.logFile=System.out \
-       -jar "$JAR" "$@" >> "$LOG" 2>"$tmpstderr" || true
+       -jar "$JAR" "$@" >"$tmpstdout" 2>"$tmpstderr" || true
+  cat "$tmpstdout" >> "$LOG"
   cat "$tmpstderr" >> "$LOG"
-  _run_stderr=$(cat "$tmpstderr")
+  _run_output=$(cat "$tmpstdout")
+  _run_output+=$'\n'
+  _run_output+=$(cat "$tmpstderr")
+  rm -f "$tmpstdout"
   rm -f "$tmpstderr"
   echo "" >> "$LOG"
 }
@@ -117,21 +154,47 @@ pg_blob_size() {
 # Helper: truncate all HA tables so each HA-PG run starts clean.
 pg_truncate() {
   docker exec "$PG_CONTAINER" psql -U retentiontest -d retentiontest -c \
-    "TRUNCATE drools_ansible_session_state, drools_ansible_matching_event, drools_ansible_action_info, drools_ansible_ha_stats" >/dev/null 2>&1 || true
+    "TRUNCATE drools_ansible_session_state, drools_ansible_event_record, drools_ansible_matching_event, drools_ansible_action_info, drools_ansible_ha_stats" >/dev/null 2>&1 || true
 }
 
-# Helper: extract metrics from stderr
+# Helper: extract metrics from command output.
+# Prefer the CSV summary line because it is emitted after the GC/sleep/GC block
+# that the load test uses for its retention measurement. Fall back to the
+# structured log lines only if the CSV summary is missing or invalid.
 parse_metrics() {
-  local stderr_output="$1"
+  local run_output="$1"
   local filename="$2"
   local metrics_line
-  metrics_line=$(echo "$stderr_output" | grep "^${filename}" | tail -1)
-  if [ -z "$metrics_line" ]; then
-    _mem="FAILED"
-    _time="FAILED"
-  else
+  local stats_line
+  local time_line
+
+  metrics_line=$(printf "%s\n" "$run_output" | grep -F "${filename}" | grep -F "," | tail -1 || true)
+  if [ -n "$metrics_line" ]; then
     _mem=$(echo "$metrics_line" | cut -d',' -f2 | tr -d ' ')
     _time=$(echo "$metrics_line" | cut -d',' -f3 | tr -d ' ')
+  else
+    _mem=""
+    _time=""
+  fi
+
+  if [ -z "$_mem" ] || [ -z "$_time" ] || { [ "$_mem" = "0" ] && [ "$_time" = "0" ]; }; then
+    stats_line=$(printf "%s\n" "$run_output" | grep '"usedMemory":' | tail -1 || true)
+    time_line=$(printf "%s\n" "$run_output" | grep -E 'Executed in [0-9]+ msecs|\*\*\* End measuring execution time , duration = [0-9]+ ms' | tail -1 || true)
+
+    if [ -n "$stats_line" ]; then
+      _mem=$(printf "%s\n" "$stats_line" | sed -n 's/.*"usedMemory":\([0-9][0-9]*\).*/\1/p')
+    fi
+    if [ -n "$time_line" ]; then
+      _time=$(printf "%s\n" "$time_line" | sed -n 's/.*duration = \([0-9][0-9]*\) ms.*/\1/p')
+      if [ -z "$_time" ]; then
+        _time=$(printf "%s\n" "$time_line" | sed -n 's/.*Executed in \([0-9][0-9]*\) msecs.*/\1/p')
+      fi
+    fi
+  fi
+
+  if [ -z "$_mem" ] || [ -z "$_time" ]; then
+    _mem="FAILED"
+    _time="FAILED"
   fi
 }
 
@@ -140,16 +203,16 @@ parse_metrics() {
   echo "=== Event Retention Memory Analysis ==="
   echo "Event payload: ~24KB JSON each (2-condition join, all retained as partial matches)"
   echo ""
-  printf "%-10s %-8s %14s %9s %14s %10s %14s\n" \
-    "Mode" "Events" "Memory(bytes)" "Time(ms)" "Per-Event(KB)" "MATCHING" "BlobSize(B)"
-  printf "%s\n" "$(head -c 88 < /dev/zero | tr '\0' '-')"
+  printf "%-10s %-8s %14s %9s %14s %10s %10s %14s\n" \
+    "Mode" "Events" "Memory(bytes)" "Time(ms)" "Per-Event(KB)" "EVENT_REC" "MATCHING" "BlobSize(B)"
+  printf "%s\n" "$(head -c 100 < /dev/zero | tr '\0' '-')"
 } | tee "$OUT"
 
 # Associative arrays to store results for delta calculation
 declare -A MEM_RESULTS
 
 for run_mode in noHA HA-PG; do
-  for idx in 0 1 2; do
+  for idx in "${!FILES[@]}"; do
     file="${FILES[$idx]}"
     count="${COUNTS[$idx]}"
     size="${SIZES[$idx]}"
@@ -158,16 +221,18 @@ for run_mode in noHA HA-PG; do
 
     if [ "$run_mode" = "noHA" ]; then
       run_java "$file ($run_mode)" "$file"
+      event_record_rows="-"
       matching_rows="-"
       blob_size="-"
     else
       pg_truncate
       run_java "$file ($run_mode)" "$file" --ha-db-params "$PG_PARAMS"
+      event_record_rows=$(pg_count "drools_ansible_event_record")
       matching_rows=$(pg_count "drools_ansible_matching_event")
       blob_size=$(pg_blob_size)
     fi
 
-    parse_metrics "$_run_stderr" "$file"
+    parse_metrics "$_run_output" "$file"
     mem="$_mem"
     time="$_time"
 
@@ -177,8 +242,8 @@ for run_mode in noHA HA-PG; do
       per_event=$(awk "BEGIN { printf \"%.1f\", $mem / $count / 1024 }")
     fi
 
-    printf "%-10s %-8s %14s %9s %14s %10s %14s\n" \
-      "$run_mode" "$size" "$mem" "$time" "$per_event" "$matching_rows" "$blob_size" | tee -a "$OUT"
+    printf "%-10s %-8s %14s %9s %14s %10s %10s %14s\n" \
+      "$run_mode" "$size" "$mem" "$time" "$per_event" "$event_record_rows" "$matching_rows" "$blob_size" | tee -a "$OUT"
 
     # Store for delta calculation
     MEM_RESULTS["${run_mode}_${idx}"]="$mem"
@@ -194,7 +259,11 @@ done
   printf "%s\n" "$(head -c 54 < /dev/zero | tr '\0' '-')"
 
   for run_mode in noHA HA-PG; do
-    for pair in "0:1:100-500:400" "1:2:500-1k:500"; do
+    for pair in \
+      "0:1:100-500:400" \
+      "1:2:500-1k:500" \
+      "2:3:1k-5k:4000" \
+      "3:4:5k-10k:5000"; do
       IFS=':' read -r from_idx to_idx label delta_count <<< "$pair"
       from_mem="${MEM_RESULTS["${run_mode}_${from_idx}"]}"
       to_mem="${MEM_RESULTS["${run_mode}_${to_idx}"]}"
@@ -215,7 +284,12 @@ done
   printf "%-12s %14s %14s\n" "Range" "Delta(bytes)" "Per-Event(KB)"
   printf "%s\n" "$(head -c 42 < /dev/zero | tr '\0' '-')"
 
-  for pair in "0:100:100" "1:500:500" "2:1k:1000"; do
+  for pair in \
+    "0:100:100" \
+    "1:500:500" \
+    "2:1k:1000" \
+    "3:5k:5000" \
+    "4:10k:10000"; do
     IFS=':' read -r idx label count <<< "$pair"
     noha_mem="${MEM_RESULTS["noHA_${idx}"]}"
     ha_mem="${MEM_RESULTS["HA-PG_${idx}"]}"

--- a/drools-ansible-rulebook-integration-main/load_test_temporal.sh
+++ b/drools-ansible-rulebook-integration-main/load_test_temporal.sh
@@ -8,7 +8,7 @@
 # test, so MATCHING_EVENT rows accumulate.
 # Single-node, PostgreSQL only (no failover phase).
 # Reports load time, memory, and final DB row counts for
-# SESSION_STATE / MATCHING_EVENT / ACTION_INFO.
+# SESSION_STATE / EVENT_RECORD / MATCHING_EVENT / ACTION_INFO.
 #
 # Requires Docker for PostgreSQL.
 
@@ -136,10 +136,15 @@ pg_count() {
   echo "$count"
 }
 
+pg_blob_size() {
+  docker exec "$PG_CONTAINER" psql -U temporaltest -d temporaltest -tAc \
+    "SELECT COALESCE(MAX(length(partial_matching_events)), 0) FROM drools_ansible_session_state" 2>/dev/null || echo "ERR"
+}
+
 # 4) Header
 header=$(printf "=== Temporal Operator Load Test (once_within, size=%s) ===" "$size")
-table_header=$(printf "\n%-30s %14s %9s %10s %10s %10s" "File" "Memory(bytes)" "Time(ms)" "SESSION" "MATCHING" "ACTION")
-separator=$(printf "%s" "$(head -c 95 < /dev/zero | tr '\0' '-')")
+table_header=$(printf "\n%-30s %14s %9s %10s %10s %10s %10s %14s" "File" "Memory(bytes)" "Time(ms)" "SESSION" "EVENT_REC" "MATCHING" "ACTION" "BlobSize(B)")
+separator=$(printf "%s" "$(head -c 120 < /dev/zero | tr '\0' '-')")
 
 {
   echo "$header"
@@ -157,13 +162,15 @@ load_mem="$_mem"; load_time="$_time"
 
 # 6) Query final DB row counts
 session_rows=$(pg_count "drools_ansible_session_state")
+event_record_rows=$(pg_count "drools_ansible_event_record")
 matching_rows=$(pg_count "drools_ansible_matching_event")
 action_rows=$(pg_count "drools_ansible_action_info")
+blob_size=$(pg_blob_size)
 
 # 7) Print results
 {
-  printf "%-30s %14s %9s %10s %10s %10s\n" \
-    "$test_file" "$load_mem" "$load_time" "$session_rows" "$matching_rows" "$action_rows"
+  printf "%-30s %14s %9s %10s %10s %10s %10s %14s\n" \
+    "$test_file" "$load_mem" "$load_time" "$session_rows" "$event_record_rows" "$matching_rows" "$action_rows" "$blob_size"
   echo ""
 } | tee -a "$out"
 

--- a/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/Main.java
+++ b/drools-ansible-rulebook-integration-main/src/main/java/org/drools/ansible/rulebook/integration/main/Main.java
@@ -109,7 +109,9 @@ public class Main {
         }
 
         executor.shutdown();
-        executor.awaitTermination(300, TimeUnit.SECONDS);
+        while (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+            LOGGER.info("Load test still running after waiting 60 seconds; continuing to wait for completion");
+        }
 
         if (foundError) {
             System.err.println("ERROR FOUND!!! Check above logs");

--- a/drools-ansible-rulebook-integration-runtime/src/main/java/org/drools/ansible/rulebook/integration/core/jpy/AstRulesEngine.java
+++ b/drools-ansible-rulebook-integration-runtime/src/main/java/org/drools/ansible/rulebook/integration/core/jpy/AstRulesEngine.java
@@ -31,6 +31,8 @@ import org.drools.ansible.rulebook.integration.ha.api.HASessionContext;
 import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
 import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
 import org.drools.ansible.rulebook.integration.ha.model.EventRecord;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordChange;
+import org.drools.ansible.rulebook.integration.ha.model.EventRecordEntry;
 import org.drools.ansible.rulebook.integration.ha.model.HAStats;
 import org.drools.ansible.rulebook.integration.ha.model.MatchingEvent;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
@@ -42,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.readValueAsMapOfStringAndObject;
 import static org.drools.ansible.rulebook.integration.api.io.JsonMapper.toJson;
+import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.calculateEventRecordsManifestSHA;
 import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.calculateStateSHA;
 import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.populateHAMatchResponse;
 import static org.drools.ansible.rulebook.integration.ha.api.HAUtils.sha256;
@@ -198,7 +201,8 @@ public class AstRulesEngine implements Closeable {
             HAStats haStats = haStateManager.getHAStats();
             haStats.incrementEventsProcessed();
             updateGlobalSessionStats(haStats);
-            haStateManager.persistSessionStateStatsAndMatchingEvents(sessionState, matchingEvents);
+            List<EventRecordChange> eventRecordChanges = rulesExecutor.getHaSessionContext().drainEventRecordChanges();
+            haStateManager.persistSessionStateStatsEventRecordsAndMatchingEvents(sessionState, eventRecordChanges, matchingEvents);
         }
 
         return haMatches;
@@ -214,6 +218,7 @@ public class AstRulesEngine implements Closeable {
 
         // Update partial events from memory
         sessionState.setPartialEvents(new ArrayList<>(recordsInMemory.values()));
+        sessionState.setEventRecordsManifestSHA(calculateEventRecordsManifestSHA(haSessionContext.snapshotEventRecordEntries()));
 
         // Update processed event IDs from memory
         sessionState.setProcessedEventIds(haSessionContext.getProcessedEventIds());
@@ -462,6 +467,7 @@ public class AstRulesEngine implements Closeable {
 
         // Phase 2: Recover all sessions in-memory, collect persistence intents
         List<SessionState> statesToPersist = new ArrayList<>();
+        Map<String, List<EventRecordEntry>> eventRecordEntriesByRuleSet = new HashMap<>();
         List<String> rulesetsToDelete = new ArrayList<>();
         List<MatchingEvent> allRecoveryMatches = new ArrayList<>();
 
@@ -474,12 +480,15 @@ public class AstRulesEngine implements Closeable {
                 if (result.sessionState() != null) {
                     statesToPersist.add(result.sessionState());
                 }
+                if (result.eventRecordEntries() != null) {
+                    eventRecordEntriesByRuleSet.put(result.sessionState().getRuleSetName(), result.eventRecordEntries());
+                }
                 allRecoveryMatches.addAll(result.recoveryMatches());
             }
         }
 
         // Phase 3: ONE persist call — single transaction
-        haStateManager.persistLeaderStartup(statesToPersist, rulesetsToDelete, allRecoveryMatches);
+        haStateManager.persistLeaderStartup(statesToPersist, eventRecordEntriesByRuleSet, rulesetsToDelete, allRecoveryMatches);
         for (MatchingEvent me : allRecoveryMatches) {
             logger.info("Persisted grace-period recovery match for rule '{}' as MatchingEvent {}", me.getRuleName(), me.getMeUuid());
         }
@@ -495,6 +504,7 @@ public class AstRulesEngine implements Closeable {
      */
     private record SessionRecoveryResult(
         SessionState sessionState,
+        List<EventRecordEntry> eventRecordEntries,
         List<MatchingEvent> recoveryMatches,
         String deleteRulesetName
     ) {}
@@ -530,7 +540,7 @@ public class AstRulesEngine implements Closeable {
             logger.info("Ruleset updated for {} - will delete old session state and persist fresh state as leader", rulesetName);
             SessionState freshState = haStateManager.getInMemorySessionState(rulesetName);
             // Return delete intent + optional fresh state to persist
-            return new SessionRecoveryResult(freshState, List.of(), rulesetName);
+            return new SessionRecoveryResult(freshState, null, List.of(), rulesetName);
         }
 
         RulesExecutor recoveredRulesExecutor = haStateManager.recoverSession(((HARulesExecutor) executor).getRulesetString(), persistedSessionState, executor.asKieSession().getSessionClock().getCurrentTime());
@@ -553,11 +563,12 @@ public class AstRulesEngine implements Closeable {
         // Update in-memory state from recovered executor (refreshes partialEvents from WM)
         haStateManager.registerSessionState(rulesetName, persistedSessionState);
         updateInMemorySessionState((HARulesExecutor) recoveredRulesExecutor, persistedSessionState);
+        List<EventRecordEntry> eventRecordEntries = ((HARulesExecutor) recoveredRulesExecutor).getHaSessionContext().snapshotEventRecordEntries();
 
         logger.info("Recovered session {} from persisted SessionState", rulesetName);
 
         // Return persistence intents — no DB writes yet
-        return new SessionRecoveryResult(persistedSessionState, recoveryMatches, null);
+        return new SessionRecoveryResult(persistedSessionState, eventRecordEntries, recoveryMatches, null);
     }
 
     private RulesExecutor createHARulesExecutorWithSessionState(RulesSet rulesSet, String rulesetString) {
@@ -593,7 +604,8 @@ public class AstRulesEngine implements Closeable {
                     updateInMemorySessionState((HARulesExecutor) recoveredExecutor, persistedSessionState);
 
                     // Persist refreshed state + recovery matches in single transaction
-                    haStateManager.persistSessionStateAndMatchingEvents(persistedSessionState, recoveryMatches);
+                    List<EventRecordEntry> eventRecordEntries = ((HARulesExecutor) recoveredExecutor).getHaSessionContext().snapshotEventRecordEntries();
+                    haStateManager.persistSessionStateEventRecordEntriesAndMatchingEvents(persistedSessionState, eventRecordEntries, recoveryMatches);
                     for (MatchingEvent me : recoveryMatches) {
                         logger.info("Persisted grace-period recovery match for rule '{}' as MatchingEvent {}", me.getRuleName(), me.getMeUuid());
                     }
@@ -620,6 +632,7 @@ public class AstRulesEngine implements Closeable {
         sessionState.setPersistedTime(currentTime);
         sessionState.setRulebookHash(rulebookHash);
         sessionState.setLeaderId(haStateManager.getLeaderId());
+        sessionState.setEventRecordsManifestSHA(calculateEventRecordsManifestSHA(List.of()));
 
         // Calculate initial SHA from complete state
         sessionState.setCurrentStateSHA(calculateStateSHA(sessionState));


### PR DESCRIPTION
…#178)

This reverts commit c4c2ff11e1d9f1d232282ca1df5bd9a7ab4c9e1f.

    Externalize retained EventRecords into row storage

    Replace blob-backed partial-event persistence with a dedicated drools_ansible_event_record table and wire the HA recovery path to load and persist retained EventRecords as ordered rows.

    This commit adds row-level EventRecord models and APIs, schema support in H2/PostgreSQL, manifest-based SHA handling, row-aware session persistence and recovery, and integration coverage for persistence, failover, and encryption. It also updates the load-test harness to report EventRecord rows and fixes the main load-test runner so long 10k retention runs wait for completion before emitting summary metrics.