### PR TITLE
[2.0.x] add postgres connection error log

### DIFF
--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLStateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/src/main/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLStateManager.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPool;
 import org.drools.ansible.rulebook.integration.ha.api.AbstractHAStateManager;
 import org.drools.ansible.rulebook.integration.ha.model.SessionState;
 import org.drools.ansible.rulebook.integration.ha.model.HAStats;
@@ -253,7 +254,51 @@ public class PostgreSQLStateManager extends AbstractHAStateManager {
         hikariConfig.addDataSourceProperty("prepareThreshold", 3);
         hikariConfig.addDataSourceProperty("preparedStatementCacheQueries", 256);
 
-        return new HikariDataSource(hikariConfig);
+        try {
+            return new HikariDataSource(hikariConfig);
+        } catch (HikariPool.PoolInitializationException e) {
+            String errorMessage = formatConnectionFailureMessage(host, port, database, sslmode, e);
+            logger.error(errorMessage);
+            throw new RuntimeException(errorMessage, e);
+        }
+    }
+
+    static String formatConnectionFailureMessage(String host, String port, String database, String sslmode, Throwable failure) {
+        String rootCauseMessage = describeConnectionFailure(failure);
+        return String.format(
+                "Failed to connect to PostgreSQL for HA initialization (host=%s, port=%s, database=%s, sslmode=%s): %s. " +
+                        "Verify connection parameters and network reachability.",
+                host,
+                port,
+                database,
+                sslmode,
+                rootCauseMessage);
+    }
+
+    private static String describeConnectionFailure(Throwable failure) {
+        Throwable rootCause = rootCause(failure);
+        if (rootCause != null) {
+            String className = rootCause.getClass().getSimpleName();
+            String message = rootCause.getMessage();
+            if (message != null && !message.isBlank()) {
+                return className + ": " + message;
+            }
+            if (!className.isBlank()) {
+                return className;
+            }
+        }
+        if (failure != null && failure.getMessage() != null && !failure.getMessage().isBlank()) {
+            return failure.getMessage();
+        }
+        return "unknown connection error";
+    }
+
+    private static Throwable rootCause(Throwable failure) {
+        Throwable current = failure;
+        while (current != null && current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
     }
 
     // ── Leader management ───────────────────────────────────────────────

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLConnectionFailureMessageTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/postgres/PostgreSQLConnectionFailureMessageTest.java
@@ -1,0 +1,54 @@
+package org.drools.ansible.rulebook.integration.ha.postgres;
+
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+import com.zaxxer.hikari.pool.HikariPool;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgreSQLConnectionFailureMessageTest {
+
+    @Test
+    void formatsTimeoutFailureWithCredentialContextAndRootCause() {
+        SocketTimeoutException timeout = new SocketTimeoutException("Connect timed out");
+        PSQLException driverFailure = new PSQLException("The connection attempt failed.", PSQLState.CONNECTION_UNABLE_TO_CONNECT, timeout);
+        HikariPool.PoolInitializationException poolFailure =
+                new HikariPool.PoolInitializationException(driverFailure);
+
+        String message = PostgreSQLStateManager.formatConnectionFailureMessage(
+                "54.164.199.254",
+                "5432",
+                "eda_ha",
+                "require",
+                poolFailure);
+
+        System.out.println(message);
+
+        assertThat(message).contains("host=54.164.199.254");
+        assertThat(message).contains("port=5432");
+        assertThat(message).contains("database=eda_ha");
+        assertThat(message).contains("sslmode=require");
+        assertThat(message).contains("SocketTimeoutException: Connect timed out");
+        assertThat(message).contains("Verify connection parameters and network reachability.");
+    }
+
+    @Test
+    void formatsUnknownHostFailureWithoutLeakingSensitiveValues() {
+        UnknownHostException unknownHost = new UnknownHostException("db.internal.example");
+
+        String message = PostgreSQLStateManager.formatConnectionFailureMessage(
+                "db.internal.example",
+                "5432",
+                "eda_ha",
+                "verify-full",
+                unknownHost);
+
+        assertThat(message).contains("UnknownHostException: db.internal.example");
+        assertThat(message).doesNotContain("password");
+        assertThat(message).doesNotContain("secret");
+    }
+}


### PR DESCRIPTION
Add an error log such as:
```
Failed to connect to PostgreSQL for HA initialization (host=xx.xx.xx.xx, port=5432, database=eda_ha, sslmode=require): SocketTimeoutException: Connect timed out. Verify the connection parameters and network reachability.
```
while still keeping the full stack trace.