### PR TITLE
align bouncycastle version to drools parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <!-- HA dependencies -->
     <version.h2>2.3.232</version.h2>
     <version.hikaricp>5.0.1</version.hikaricp>
-    <version.bouncycastle>1.78.1</version.bouncycastle>
+    <version.bouncycastle>1.84</version.bouncycastle>
     <version.postgresql>42.7.9</version.postgresql>
     <version.testcontainers>1.19.0</version.testcontainers>
   </properties>
@@ -120,6 +120,16 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${version.bouncycastle}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${version.bouncycastle}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
         <version>${version.bouncycastle}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- Added dependencies not to mix versions (if not, failed on test)
```
[ERROR] org.drools.ansible.rulebook.integration.ha.tests.ssl.HAIntegrationSSLTest -- Time elapsed: 0.328 s <<< ERROR!
java.lang.NoSuchFieldError: id_MLDSA44_ECDSA_brainpoolP256r1_SHA256
	at org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder.<clinit>(Unknown Source)
	at org.bouncycastle.operator.jcajce.JcaContentSignerBuilder.build(Unknown Source)
	at org.drools.ansible.rulebook.integration.ha.tests.ssl.SSLTestCertificateGenerator.buildCACertificate(SSLTestCertificateGenerator.java:136)
	at org.drools.ansible.rulebook.integration.ha.tests.ssl.SSLTestCertificateGenerator.generate(SSLTestCertificateGenerator.java:93)
	at org.drools.ansible.rulebook.integration.ha.tests.ssl.HAIntegrationSSLTest.setUpSSLPostgres(HAIntegrationSSLTest.java:76)
```
- Upgrade to `1.84` to meet the drools parent latest.