### PR TITLE
Update version and Maven repositories.

### DIFF
--- a/drools-ansible-rulebook-integration-api/pom.xml
+++ b/drools-ansible-rulebook-integration-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-benchmark/pom.xml
+++ b/drools-ansible-rulebook-integration-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-benchmark</artifactId>

--- a/drools-ansible-rulebook-integration-core-rest/pom.xml
+++ b/drools-ansible-rulebook-integration-core-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-core-rest</artifactId>

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/pom.xml
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration-ha</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-ansible-rulebook-integration-ha-core</artifactId>

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/AbstractHAStateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/AbstractHAStateManager.java
@@ -29,7 +29,7 @@ public abstract class AbstractHAStateManager implements HAStateManager {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractHAStateManager.class);
 
     protected static final String DROOLS_VERSION_KEY = "drools_version";
-    public static final String DROOLS_VERSION = "2.0.0";
+    public static final String DROOLS_VERSION = "2.0.1";
 
     private final Map<String, SessionState> sessionStateMap = new HashMap<>();
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/pom.xml
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-h2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ansible-rulebook-integration-ha</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-ansible-rulebook-integration-ha-h2</artifactId>

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/pom.xml
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-postgres/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ansible-rulebook-integration-ha</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-ansible-rulebook-integration-ha-postgres</artifactId>

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ansible-rulebook-integration-ha</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-ansible-rulebook-integration-ha-tests</artifactId>

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerDroolsVersionTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerDroolsVersionTest.java
@@ -25,7 +25,7 @@ import static org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils
 class HAStateManagerDroolsVersionTest extends HAStateManagerTestBase {
 
     private static final String DROOLS_VERSION_KEY = "drools_version";
-    private static final String EXPECTED_VERSION = "2.0.0";
+    private static final String EXPECTED_VERSION = "2.0.1";
 
     private HAStateManager stateManager;
     private static final String HA_UUID = "test-ha-version";

--- a/drools-ansible-rulebook-integration-ha/pom.xml
+++ b/drools-ansible-rulebook-integration-ha/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ansible-rulebook-integration</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-ansible-rulebook-integration-ha</artifactId>

--- a/drools-ansible-rulebook-integration-load-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-load-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-main/pom.xml
+++ b/drools-ansible-rulebook-integration-main/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-migration-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-migration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-protoextractor/pom.xml
+++ b/drools-ansible-rulebook-integration-protoextractor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-runtime/pom.xml
+++ b/drools-ansible-rulebook-integration-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   
   <artifactId>drools-ansible-rulebook-integration-runtime</artifactId>

--- a/drools-ansible-rulebook-integration-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-ansible-rulebook-integration-visualization/pom.xml
+++ b/drools-ansible-rulebook-integration-visualization/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-ansible-rulebook-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.drools>999-SNAPSHOT</version.drools>
+    <version.drools>111-SNAPSHOT</version.drools>
     <version.org.antlr4>4.13.0</version.org.antlr4><!-- antlr4 (and exec:java) maven plugins not managed in drools-build-parent -->
     <version.jmh>1.35</version.jmh>
 
@@ -57,9 +57,9 @@
       </snapshots>
     </repository>
     <repository>
-      <id>apache-public-repository-group</id>
-      <name>Apache Public Repository Group</name>
-      <url>https://repository.apache.org/content/groups/public/</url>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/logic-maven-repository</url>
       <layout>default</layout>
       <releases>
         <enabled>false</enabled>
@@ -82,9 +82,9 @@
       </snapshots>
     </pluginRepository>
     <pluginRepository>
-      <id>apache-public-repository-group</id>
-      <name>Apache Public Repository Group</name>
-      <url>https://repository.apache.org/content/groups/public/</url>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/logic-maven-repository</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   
   <groupId>org.drools</groupId>
   <artifactId>drools-ansible-rulebook-integration</artifactId>
-  <version>999-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
This PR: 
- Updates version to 111-SNAPSHOT to align with other repositories in kiegroup.
- Updates Drools version used to 111-SNAPSHOT. 
- Updates <repositories> configuration. 
- Updates tests to test with version 2.0.1. @tkobayas please doublecheck this if you can. Some tests were using constant version 2.0.0. As I see now we have beta tags for 2.0.1, the tests were failing, so I updated those to use version 2.0.1. 