### PR TITLE
fix(ha-core): set DROOLS_VERSION to "111" for main branch

### DIFF
--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/AbstractHAStateManager.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-core/src/main/java/org/drools/ansible/rulebook/integration/ha/api/AbstractHAStateManager.java
@@ -29,7 +29,7 @@ public abstract class AbstractHAStateManager implements HAStateManager {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractHAStateManager.class);
 
     protected static final String DROOLS_VERSION_KEY = "drools_version";
-    public static final String DROOLS_VERSION = "2.0.1";
+    public static final String DROOLS_VERSION = "111"; // for main
 
     private final Map<String, SessionState> sessionStateMap = new HashMap<>();
 

--- a/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerDroolsVersionTest.java
+++ b/drools-ansible-rulebook-integration-ha/drools-ansible-rulebook-integration-ha-tests/src/test/java/org/drools/ansible/rulebook/integration/ha/tests/state/HAStateManagerDroolsVersionTest.java
@@ -5,6 +5,7 @@ import org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils;
 import java.util.List;
 import java.util.Map;
 
+import org.drools.ansible.rulebook.integration.ha.api.AbstractHAStateManager;
 import org.drools.ansible.rulebook.integration.ha.api.HAStateManager;
 import org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory;
 import org.drools.ansible.rulebook.integration.ha.api.HAUtils;
@@ -25,7 +26,7 @@ import static org.drools.ansible.rulebook.integration.ha.tests.support.TestUtils
 class HAStateManagerDroolsVersionTest extends HAStateManagerTestBase {
 
     private static final String DROOLS_VERSION_KEY = "drools_version";
-    private static final String EXPECTED_VERSION = "2.0.1";
+    private static final String EXPECTED_VERSION = AbstractHAStateManager.DROOLS_VERSION;
 
     private HAStateManager stateManager;
     private static final String HA_UUID = "test-ha-version";


### PR DESCRIPTION
"2.0.1" was misleading on main which uses 111-SNAPSHOT. Use AbstractHAStateManager.DROOLS_VERSION in the version test instead of a hardcoded string.

Resolves #207