### PR TITLE
[2.0.x] fix purge call concurrency

### DIFF
--- a/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/RulesExecutorSession.java
+++ b/drools-ansible-rulebook-integration-api/src/main/java/org/drools/ansible/rulebook/integration/api/rulesengine/RulesExecutorSession.java
@@ -34,7 +34,7 @@ public class RulesExecutorSession {
 
     private static final Logger log = LoggerFactory.getLogger(RulesExecutorSession.class);
     private static final String PURGE_CANCELLED_JOB_EVENT_COUNT_THRESHOLD_PROPERTY = "drools.purge.cancelled.job.event.count.threshold";
-    private static final int DEFAULT_PURGE_CANCELLED_JOB_EVENT_COUNT_THRESHOLD = 10;
+    private static final int DEFAULT_PURGE_CANCELLED_JOB_EVENT_COUNT_THRESHOLD = 100;
     private static final int PURGE_CANCELLED_JOB_EVENT_COUNT_THRESHOLD;
 
     static {
@@ -135,7 +135,9 @@ public class RulesExecutorSession {
             if (timerService instanceof PseudoClockScheduler scheduler) {
                 Method purgeCancelledJob = PseudoClockScheduler.class.getDeclaredMethod("purgeCancelledJob");
                 purgeCancelledJob.setAccessible(true);
-                purgeCancelledJob.invoke(scheduler);
+                synchronized (scheduler) {
+                    purgeCancelledJob.invoke(scheduler);
+                }
             }
         } catch (ReflectiveOperationException e) {
             log.warn("Unable to purge cancelled pseudo-clock jobs after deleting event {}", fh.getId(), e);

--- a/drools-ansible-rulebook-integration-tests/pom.xml
+++ b/drools-ansible-rulebook-integration-tests/pom.xml
@@ -38,6 +38,12 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-ansible-rulebook-integration-api</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ansible-rulebook-integration-api</artifactId>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Occasionally happens in drools-ansible-rulebook-integration-load-tests/load_test_match_unmatch_noHA_HA-PG.sh
```
=== 24kb_10k_events_unmatch.json (HA-PG) ===
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - Initializing HA mode with UUID: loadtest-ha-1781663337948 and workerName: loadtest-worker
[main] INFO org.drools.ansible.rulebook.integration.ha.api.HAStateManagerFactory - Created PostgreSQLStateManager instance (db_type=postgres)
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - Initializing PostgreSQL HA mode with UUID: loadtest-ha-1781663337948, workerName: loadtest-worker
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - Connecting to PostgreSQL at localhost:52669/loadtest
[main] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
[main] INFO com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@126253fd
[main] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLSchema - PostgreSQL schema already exists (tables were likely created by another process)
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - PostgreSQL HA initialization completed successfully
[main] INFO org.drools.ansible.rulebook.integration.ha.api.AbstractHAStateManager - HA encryption disabled (no encryption_key_primary in config)
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - HA deduplication buffer size set to 5
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - HA overwrite_if_rulebook_changes set to true
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - HA mode initialized successfully
[main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.RulesExecutorSession - Cancelled pseudo-clock job purge threshold set to 10
[main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Memory occupation threshold set to 90%
[main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Memory check event count threshold set to 64
[main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.MemoryMonitorUtil - Exit above memory occupation threshold set to false
[main] INFO org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator - Start automatic pseudo clock with a tick every 100 milliseconds
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - Enabling leader mode for: loadtest-worker
[drools-async-evaluator-thread] INFO org.drools.ansible.rulebook.integration.api.io.RuleExecutorChannel - Async channel connected
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - Restored HA stats from PostgreSQL database
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - Leader mode enabled for: loadtest-worker
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - Persisted leader startup in single transaction: 0 session states, 0 deletes, 0 matching events
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - Checking for pending matching events to recover
[main] INFO org.drools.ansible.rulebook.integration.core.jpy.AstRulesEngine - No pending matching events to recover
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - HA startup summary [ha_uuid=loadtest-ha-1781663337948, leader=loadtest-worker]: 0 session(s), 0 partial event(s), 0 pending matching event(s), 0 pending action(s), leader switches: 1
[main] INFO org.drools.ansible.rulebook.integration.loadtests.HaLoadRunner - *** Start measuring execution time
[drools-async-evaluator-thread] WARN org.drools.ansible.rulebook.integration.api.rulesengine.RulesExecutorSession - Unable to purge cancelled pseudo-clock jobs after deleting event 2780
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.drools.ansible.rulebook.integration.api.rulesengine.RulesExecutorSession.purgeCancelledJobsIfSupported(RulesExecutorSession.java:138)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.lambda$process$11(AbstractRulesEvaluator.java:191)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.atomicRuleEvaluation(AbstractRulesEvaluator.java:281)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.process(AbstractRulesEvaluator.java:184)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.lambda$processEvents$2(AbstractRulesEvaluator.java:110)
	at org.drools.ansible.rulebook.integration.api.rulesengine.SyncRulesEvaluator.lambda$engineEvaluate$0(SyncRulesEvaluator.java:25)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AsyncExecutor.lambda$submit$1(AsyncExecutor.java:24)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.PriorityQueue$Itr.next(PriorityQueue.java:520)
	at org.drools.core.time.impl.PseudoClockScheduler.purgeCancelledJob(PseudoClockScheduler.java:187)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	... 12 more
[main] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
[main] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.
[main] INFO org.drools.ansible.rulebook.integration.ha.postgres.PostgreSQLStateManager - PostgreSQL HA state manager shut down
[main] INFO org.drools.ansible.rulebook.integration.api.RulesExecutor - Disposing session with id: 1; SessionStats{start='2026-06-17T02:28:58.531116936Z', end='2026-06-17T02:29:05.059492467Z', lastClockTime='2026-06-17T02:29:04.943Z', clockAdvanceCount=64, numberOfRules=1, numberOfDisabledRules=0, rulesTriggered=0, eventsProcessed=5080, eventsMatched=0, eventsSuppressed=5080, permanentStorageCount=1, permanentStorageSize=23979, asyncResponses=0, bytesSentOnAsync=0, sessionId=1, ruleSetName='24kb 10k events unmatch', lastRuleFired='', lastRuleFiredAt='null', lastEventReceivedAt='2026-06-17T02:29:04.943Z', baseLevelMemory='8269448', usedMemory='8823104', peakMemory='30559496', maxAvailableMemory='1073741824'}
Exception in thread "main" java.util.concurrent.CompletionException: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 11
	at org.drools.ansible.rulebook.integration.api.rulesengine.AsyncExecutor.lambda$submit$1(AsyncExecutor.java:26)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 11
	at java.base/java.util.PriorityQueue.siftUpComparable(PriorityQueue.java:652)
	at java.base/java.util.PriorityQueue.siftUp(PriorityQueue.java:639)
	at java.base/java.util.PriorityQueue.offer(PriorityQueue.java:330)
	at java.base/java.util.PriorityQueue.add(PriorityQueue.java:311)
	at org.drools.core.time.impl.PseudoClockScheduler.internalSchedule(PseudoClockScheduler.java:112)
	at org.drools.core.time.impl.PseudoClockScheduler.scheduleJob(PseudoClockScheduler.java:104)
	at org.drools.core.phreak.PropagationEntry$Insert.scheduleExpiration(PropagationEntry.java:289)
	at org.drools.core.phreak.PropagationEntry$Insert.scheduleExpiration(PropagationEntry.java:266)
	at org.drools.core.phreak.PropagationEntry$Insert.<init>(PropagationEntry.java:227)
	at org.drools.core.reteoo.EntryPointNode.assertObject(EntryPointNode.java:203)
	at org.drools.kiesession.entrypoints.NamedEntryPoint.insert(NamedEntryPoint.java:269)
	at org.drools.kiesession.entrypoints.NamedEntryPoint.insert(NamedEntryPoint.java:234)
	at org.drools.kiesession.session.StatefulKnowledgeSessionImpl.insert(StatefulKnowledgeSessionImpl.java:1287)
	at org.drools.kiesession.session.StatefulKnowledgeSessionImpl.insert(StatefulKnowledgeSessionImpl.java:1247)
	at org.drools.kiesession.session.StatefulKnowledgeSessionImpl.insert(StatefulKnowledgeSessionImpl.java:1241)
	at org.drools.ansible.rulebook.integration.api.rulesengine.RulesExecutorSession.insert(RulesExecutorSession.java:107)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.insertFacts(AbstractRulesEvaluator.java:216)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.lambda$process$10(AbstractRulesEvaluator.java:185)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.atomicRuleEvaluation(AbstractRulesEvaluator.java:270)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.process(AbstractRulesEvaluator.java:184)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AbstractRulesEvaluator.lambda$processEvents$2(AbstractRulesEvaluator.java:110)
	at org.drools.ansible.rulebook.integration.api.rulesengine.SyncRulesEvaluator.lambda$engineEvaluate$0(SyncRulesEvaluator.java:25)
	at org.drools.ansible.rulebook.integration.api.rulesengine.AsyncExecutor.lambda$submit$1(AsyncExecutor.java:24)
	... 4 more

EVENT_RECORD_COUNT [24kb_10k_events_unmatch.json (HA-PG)]: 0
```

I was not able to create a simple unit test to reproduce this.